### PR TITLE
Amber Scoop Layer: capture index buffers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,11 +92,11 @@ jobs:
           pushd ./../.github/actions/
             git clone https://github.com/actions/setup-python.git
             pushd setup-python/
-              git checkout 807b74f98ca701f414ddaa8a4187e7cffa93cbbd  # v2.0.1
+              git checkout 41b7212b1668f5de9d65e9c82aa777e6bbedb3a8  # v2.1.4
             popd
             git clone https://github.com/actions/checkout.git
             pushd checkout/
-              git checkout 28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b  # v2.3.1
+              git checkout 5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
             popd
           popd
         shell: bash

--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -31,11 +31,11 @@ jobs:
           pushd ./../.github/actions/
             git clone https://github.com/actions/setup-python.git
             pushd setup-python/
-              git checkout 807b74f98ca701f414ddaa8a4187e7cffa93cbbd  # v2.0.1
+              git checkout 41b7212b1668f5de9d65e9c82aa777e6bbedb3a8  # v2.1.4
             popd
             git clone https://github.com/actions/checkout.git
             pushd checkout/
-              git checkout 28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b  # v2.3.1
+              git checkout 5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
             popd
           popd
         shell: bash

--- a/scripts/generate_files.py
+++ b/scripts/generate_files.py
@@ -30,7 +30,7 @@ code in each VkLayer_* directory.
 The C++ files must include commented layer properties like this:
 
     "VkLayer_GF_frame_counter",     // layerName
-    VK_MAKE_VERSION(1U, 1U, 130U),  // specVersion NOLINT(hicpp-signed-bitwise)
+    VK_MAKE_VERSION(1U, 1U, 130U),  // specVersion
     1,                              // implementationVersion
     "Frame counter layer.",         // description
 

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   -fuchsia-default-arguments-calls,
   -fuchsia-statically-constructed-objects,
   -mpi-*,
+  -hicpp-signed-bitwise,
 
 # Some comments for the above:
 
@@ -25,6 +26,9 @@ Checks: >
 
 # We don't use MPI and some mpi-* checks appear to cause clang-tidy segfaults.
 # -mpi-*,
+
+# Too many false-positives!
+# -hicpp-signed-bitwise,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*gf_layers.*|.*VkLayer_GF_.*'

--- a/src/VkLayer_GF_amber_scoop/CMakeLists.txt
+++ b/src/VkLayer_GF_amber_scoop/CMakeLists.txt
@@ -14,13 +14,16 @@
 
 set(VkLayer_GF_amber_scoop_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/amber_scoop_layer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/buffer_copy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/command_buffer_data.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/create_info_wrapper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/draw_call_tracker.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/graphics_pipeline_data.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/vk_deep_copy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/vulkan_commands.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/vulkan_util.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/amber_scoop_layer.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/buffer_copy.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/command_buffer_data.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/draw_call_tracker.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/graphics_pipeline_data.cc

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/amber_scoop_layer.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/amber_scoop_layer.h
@@ -41,12 +41,14 @@ struct InstanceData {
   // vkEnumerateDeviceExtensionProperties.
   PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties;
 
-  // Other instance functions: (none)
+  // Other instance functions: (used but not intercepted)
+  PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties;
 };
 
 struct DeviceData {
   VkDevice device = {};
   InstanceData* instance_data = {};
+  VkPhysicalDevice physical_device = {};
 
   // Most layers must store this. Required to implement vkGetDeviceProcAddr.
   // Should not be used otherwise; all required device function pointers
@@ -55,6 +57,10 @@ struct DeviceData {
 
   // Other device functions:
 
+  PFN_vkAllocateCommandBuffers vkAllocateCommandBuffers = {};
+  PFN_vkFreeCommandBuffers vkFreeCommandBuffers = {};
+  PFN_vkCreateBuffer vkCreateBuffer = {};
+  PFN_vkDestroyBuffer vkDestroyBuffer = {};
   PFN_vkCreateGraphicsPipelines vkCreateGraphicsPipelines = {};
   PFN_vkCreateShaderModule vkCreateShaderModule = {};
   PFN_vkDestroyShaderModule vkDestroyShaderModule = {};
@@ -62,10 +68,30 @@ struct DeviceData {
   PFN_vkCmdBeginRenderPass vkCmdBeginRenderPass = {};
   PFN_vkCmdDraw vkCmdDraw = {};
   PFN_vkCmdDrawIndexed vkCmdDrawIndexed = {};
+  PFN_vkCmdBindIndexBuffer vkCmdBindIndexBuffer = {};
   PFN_vkCmdBindPipeline vkCmdBindPipeline = {};
+  PFN_vkCmdBindVertexBuffers vkCmdBindVertexBuffers = {};
+  PFN_vkCmdPipelineBarrier vkCmdPipelineBarrier = {};
+
+  // Functions used by the layer but not intercepted:
+  PFN_vkAllocateMemory vkAllocateMemory = {};
+  PFN_vkFreeMemory vkFreeMemory = {};
+  PFN_vkBeginCommandBuffer vkBeginCommandBuffer = {};
+  PFN_vkEndCommandBuffer vkEndCommandBuffer = {};
+  PFN_vkBindBufferMemory vkBindBufferMemory = {};
+  PFN_vkCmdCopyBuffer vkCmdCopyBuffer = {};
+  PFN_vkCreateFence vkCreateFence = {};
+  PFN_vkDestroyFence vkDestroyFence = {};
+  PFN_vkGetBufferMemoryRequirements vkGetBufferMemoryRequirements = {};
+  PFN_vkInvalidateMappedMemoryRanges vkInvalidateMappedMemoryRanges = {};
+  PFN_vkMapMemory vkMapMemory = {};
+  PFN_vkQueueWaitIdle vkQueueWaitIdle = {};
+  PFN_vkUnmapMemory vkUnmapMemory = {};
+  PFN_vkWaitForFences vkWaitForFences = {};
 
   // Tracked device data:
 
+  ProtectedMap<VkBuffer, BufferData> buffers;
   ProtectedMap<VkCommandBuffer, CommandBufferData> command_buffers_data;
   ProtectedMap<VkPipeline, std::unique_ptr<GraphicsPipelineData>>
       graphics_pipelines;

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/buffer_copy.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/buffer_copy.h
@@ -22,6 +22,7 @@
 
 #include "VkLayer_GF_amber_scoop/amber_scoop_layer.h"
 #include "VkLayer_GF_amber_scoop/vulkan_commands.h"
+#include "absl/types/span.h"
 
 namespace gf_layers::amber_scoop_layer {
 

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/buffer_copy.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/buffer_copy.h
@@ -56,14 +56,16 @@ class BufferCopy {
   BufferCopy& operator=(const BufferCopy&) = delete;
   BufferCopy& operator=(BufferCopy&&) = delete;
 
-  // Get pointer to the copied data.
-  [[nodiscard]] const uint8_t* GetCopiedData() const {
-    return reinterpret_cast<uint8_t*>(copied_data_);
+  // Get a memory view to the copied data.
+  [[nodiscard]] const absl::Span<const char>& GetCopiedData() const {
+    return copied_data_span_;
   }
 
  private:
   // Pointer to copied data.
   void* copied_data_ = nullptr;
+  // Memory view to the copied data.
+  absl::Span<const char> copied_data_span_;
 
   // Vulkan objects used
   VkBuffer buffer_copy_ = VK_NULL_HANDLE;

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/buffer_copy.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/buffer_copy.h
@@ -1,0 +1,82 @@
+// Copyright 2020 The gf-layers Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VKLAYER_GF_AMBER_SCOOP_BUFFER_COPY_H
+#define VKLAYER_GF_AMBER_SCOOP_BUFFER_COPY_H
+
+#include <vulkan/vulkan.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "VkLayer_GF_amber_scoop/amber_scoop_layer.h"
+#include "VkLayer_GF_amber_scoop/vulkan_commands.h"
+
+namespace gf_layers::amber_scoop_layer {
+
+// Class used to copy contents of a Vulkan buffer to a host visible memory. The
+// source buffer must be created with |VK_BUFFER_USAGE_TRANSFER_SRC_BIT|. The
+// layer sets that flag in |vkCreateBuffer| for all buffers we are interested
+// in. The copy operation is executed in the constructor. The data can be
+// accessed via |GetCopiedData()| function. Remaining Vulkan objects are deleted
+// in the destructor.
+class BufferCopy {
+ public:
+  // Starts the copy operation and waits until finished.
+  //
+  // |device_data| device data reference.
+  // |buffer| Vulkan buffer where the data is copied from.
+  // |buffer_size| Size of the source buffer.
+  // |queue| Vulkan queue where the commands will be submitted to.
+  // |command_pool| command pool used to allocate the commands.
+  // |pipeline_barriers| list of pipeline barriers that must be used to
+  // synchronize access to the source buffer.
+  BufferCopy(DeviceData* device_data, const VkBuffer& buffer,
+             VkDeviceSize buffer_size, VkQueue queue,
+             VkCommandPool command_pool,
+             const std::vector<const CmdPipelineBarrier*>& pipeline_barriers);
+
+  // Releases remaining Vulkan resources.
+  ~BufferCopy();
+
+  // Disabled copy/move constructors and copy/move assign operators.
+  BufferCopy(const BufferCopy&) = delete;
+  BufferCopy(BufferCopy&&) = delete;
+  BufferCopy& operator=(const BufferCopy&) = delete;
+  BufferCopy& operator=(BufferCopy&&) = delete;
+
+  // Get pointer to the copied data.
+  [[nodiscard]] const uint8_t* GetCopiedData() const {
+    return reinterpret_cast<uint8_t*>(copied_data_);
+  }
+
+ private:
+  // Pointer to copied data.
+  void* copied_data_ = nullptr;
+
+  // Vulkan objects used
+  VkBuffer buffer_copy_ = VK_NULL_HANDLE;
+  VkDeviceMemory buffer_copy_memory_ = VK_NULL_HANDLE;
+  DeviceData* device_data_;
+
+  // Find a memory type in |memory_type_bits| that includes all of
+  // |required_properties|.
+  // |memory_type_bits| is bit field from |VkMemoryRequirements.memoryTypeBits|.
+  uint32_t FindMemoryType(uint32_t memory_type_bits,
+                          VkMemoryPropertyFlags required_properties);
+};
+
+}  // namespace gf_layers::amber_scoop_layer
+
+#endif  // VKLAYER_GF_AMBER_SCOOP_BUFFER_COPY_H

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/buffer_copy.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/buffer_copy.h
@@ -18,10 +18,8 @@
 #include <vulkan/vulkan.h>
 
 #include <cstdint>
-#include <vector>
 
 #include "VkLayer_GF_amber_scoop/amber_scoop_layer.h"
-#include "VkLayer_GF_amber_scoop/vulkan_commands.h"
 #include "absl/types/span.h"
 
 namespace gf_layers::amber_scoop_layer {
@@ -41,12 +39,9 @@ class BufferCopy {
   // |buffer_size| Size of the source buffer.
   // |queue| Vulkan queue where the commands will be submitted to.
   // |command_pool| command pool used to allocate the commands.
-  // |pipeline_barriers| list of pipeline barriers that must be used to
-  // synchronize access to the source buffer.
   BufferCopy(DeviceData* device_data, const VkBuffer& buffer,
              VkDeviceSize buffer_size, VkQueue queue,
-             VkCommandPool command_pool,
-             const std::vector<const CmdPipelineBarrier*>& pipeline_barriers);
+             VkCommandPool command_pool);
 
   // Releases remaining Vulkan resources.
   ~BufferCopy();

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/command_buffer_data.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/command_buffer_data.h
@@ -32,7 +32,7 @@ namespace gf_layers::amber_scoop_layer {
 // commands without races.
 class CommandBufferData {
  public:
-  explicit CommandBufferData(VkCommandBufferAllocateInfo allocate_info)
+  explicit CommandBufferData(const VkCommandBufferAllocateInfo& allocate_info)
       : allocate_info_(allocate_info) {}
 
   // Adds |cmd| to the command list.
@@ -51,13 +51,13 @@ class CommandBufferData {
   // Sets the command buffer as submitted.
   void SetSubmitted() { is_submitted_ = true; }
 
-  const VkCommandBufferAllocateInfo* GetAllocateInfo() {
+  [[nodiscard]] const VkCommandBufferAllocateInfo* GetAllocateInfo() const {
     return &allocate_info_;
   }
 
  private:
   // VkCommandBufferAllocateInfo used to allocate this command buffer.
-  VkCommandBufferAllocateInfo allocate_info_;
+  const VkCommandBufferAllocateInfo allocate_info_;
   // Flag to tell if the command buffer has been submitted.
   bool is_submitted_ = false;
   // Flag to tell if the command list contains any draw calls.

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/command_buffer_data.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/command_buffer_data.h
@@ -15,6 +15,8 @@
 #ifndef VKLAYER_GF_AMBER_SCOOP_COMMAND_BUFFER_DATA_H
 #define VKLAYER_GF_AMBER_SCOOP_COMMAND_BUFFER_DATA_H
 
+#include <vulkan/vulkan.h>
+
 #include <memory>
 #include <vector>
 
@@ -30,6 +32,9 @@ namespace gf_layers::amber_scoop_layer {
 // commands without races.
 class CommandBufferData {
  public:
+  explicit CommandBufferData(VkCommandBufferAllocateInfo allocate_info)
+      : allocate_info_(allocate_info) {}
+
   // Adds |cmd| to the command list.
   void AddCommand(std::unique_ptr<Cmd> cmd);
 
@@ -46,7 +51,13 @@ class CommandBufferData {
   // Sets the command buffer as submitted.
   void SetSubmitted() { is_submitted_ = true; }
 
+  const VkCommandBufferAllocateInfo* GetAllocateInfo() {
+    return &allocate_info_;
+  }
+
  private:
+  // VkCommandBufferAllocateInfo used to allocate this command buffer.
+  VkCommandBufferAllocateInfo allocate_info_;
   // Flag to tell if the command buffer has been submitted.
   bool is_submitted_ = false;
   // Flag to tell if the command list contains any draw calls.

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/command_buffer_data.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/command_buffer_data.h
@@ -48,8 +48,9 @@ class CommandBufferData {
     return command_list;
   }
 
-  // Sets the command buffer as submitted.
-  void SetSubmitted() { is_submitted_ = true; }
+  // Resets this instance to the state before adding any commands to it, i.e.
+  // clears the command list and |contains_draw_calls_| flag.
+  void ResetState();
 
   [[nodiscard]] const VkCommandBufferAllocateInfo* GetAllocateInfo() const {
     return &allocate_info_;
@@ -58,8 +59,6 @@ class CommandBufferData {
  private:
   // VkCommandBufferAllocateInfo used to allocate this command buffer.
   const VkCommandBufferAllocateInfo allocate_info_;
-  // Flag to tell if the command buffer has been submitted.
-  bool is_submitted_ = false;
   // Flag to tell if the command list contains any draw calls.
   bool contains_draw_calls_ = false;
   // List of tracked commands.

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/create_info_wrapper.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/create_info_wrapper.h
@@ -33,13 +33,15 @@ class CreateInfoWrapper {
   explicit CreateInfoWrapper(const CreateInfoType& create_info)
       : create_info_(DeepCopy(create_info)) {}
 
+  // Default move constructor and move assign operator.
+  CreateInfoWrapper(CreateInfoWrapper&& other) noexcept = default;
+  CreateInfoWrapper& operator=(CreateInfoWrapper&& other) noexcept = default;
+
   virtual ~CreateInfoWrapper() { DeepDelete(create_info_); }
 
-  // Disabled copy/move constructors and copy/move assign operators.
+  // Disabled copy constructor and copy assign operator.
   CreateInfoWrapper(const CreateInfoWrapper&) = delete;
-  CreateInfoWrapper(CreateInfoWrapper&&) = delete;
   CreateInfoWrapper& operator=(const CreateInfoWrapper&) = delete;
-  CreateInfoWrapper& operator=(CreateInfoWrapper&&) = delete;
 
   // Returns the create info struct.
   [[nodiscard]] const CreateInfoType& GetCreateInfo() const {
@@ -52,6 +54,7 @@ class CreateInfoWrapper {
 
 // Type aliases for create info structs wrapped to CreateInfoWrapper.
 
+using BufferData = CreateInfoWrapper<VkBufferCreateInfo>;
 using ShaderModuleData = CreateInfoWrapper<VkShaderModuleCreateInfo>;
 
 }  // namespace gf_layers::amber_scoop_layer

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/draw_call_tracker.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/draw_call_tracker.h
@@ -90,7 +90,7 @@ class DrawCallTracker {
   void CreateIndexBufferDeclarations(
       DeviceData* device_data, uint32_t index_count,
       std::ostringstream& declaration_string_stream,
-      std::ostringstream& pipeline_string_stream);
+      std::ostringstream& pipeline_string_stream) const;
 
   DrawCallState draw_call_state_ = {};
   // Pointer to the global data. Used in HandleDrawCall function.

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vk_deep_copy.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vk_deep_copy.h
@@ -51,6 +51,17 @@ T* CopyArray(T const* p_data, uint64_t num_elements) {
 // destructors of gf_layers::amber_scoop_layer::CmdXXXX structs. See
 // vulkan_commands.h.
 
+// Makes a deep copy of VkBufferCreateInfo struct. The allocated
+// memory is not freed automatically. Use
+// DeepDelete(VkBufferCreateInfo const*) to recursively free all
+// the allocated memory.
+VkBufferCreateInfo DeepCopy(const VkBufferCreateInfo& create_info);
+
+// Recursively deletes all the allocated memory of the given
+// VkBufferCreateInfo struct. Should be used only for structs
+// created with associated DeepCopy(...) function.
+void DeepDelete(const VkBufferCreateInfo& create_info);
+
 // Makes a deep copy of VkGraphicsPipelineCreateInfo struct. The allocated
 // memory is not freed automatically. Use
 // DeepDelete(VkGraphicsPipelineCreateInfo const*) to recursively free all

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_commands.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_commands.h
@@ -15,9 +15,11 @@
 #ifndef VKLAYER_GF_AMBER_SCOOP_VULKAN_COMMANDS_H
 #define VKLAYER_GF_AMBER_SCOOP_VULKAN_COMMANDS_H
 
+#include <absl/types/span.h>
 #include <vulkan/vulkan.h>
 
 #include <cstdint>
+#include <vector>
 
 #include "VkLayer_GF_amber_scoop/vk_deep_copy.h"
 
@@ -74,6 +76,22 @@ class CmdBeginRenderPass : public Cmd {
   VkSubpassContents contents_;
 };
 
+class CmdBindIndexBuffer : public Cmd {
+ public:
+  CmdBindIndexBuffer(VkBuffer buffer, VkDeviceSize offset,
+                     VkIndexType index_type)
+      : buffer_(buffer), offset_(offset), index_type_(index_type) {}
+
+  // Sets the index buffer binding.
+  void ProcessSubmittedCommand(
+      DrawCallTracker* draw_call_state_tracker) override;
+
+ private:
+  VkBuffer buffer_;
+  VkDeviceSize offset_;
+  VkIndexType index_type_;
+};
+
 class CmdBindPipeline : public Cmd {
  public:
   CmdBindPipeline(VkPipelineBindPoint pipeline_bind_point, VkPipeline pipeline)
@@ -86,6 +104,29 @@ class CmdBindPipeline : public Cmd {
  private:
   VkPipelineBindPoint pipeline_bind_point_;
   VkPipeline pipeline_;
+};
+
+class CmdBindVertexBuffers : public Cmd {
+ public:
+  CmdBindVertexBuffers(uint32_t first_binding, uint32_t binding_count,
+                       const VkBuffer* buffers, const VkDeviceSize* offsets)
+      : first_binding_(first_binding) {
+    absl::Span<const VkBuffer> buffer_span =
+        absl::MakeConstSpan<>(buffers, binding_count);
+    absl::Span<const VkDeviceSize> offsets_span =
+        absl::MakeConstSpan<>(offsets, binding_count);
+    buffers_.assign(buffer_span.begin(), buffer_span.end());
+    offsets_.assign(offsets_span.begin(), offsets_span.end());
+  }
+
+  // Sets vertex buffer bindings and their offsets.
+  void ProcessSubmittedCommand(
+      DrawCallTracker* draw_call_state_tracker) override;
+
+ private:
+  uint32_t first_binding_;
+  std::vector<VkBuffer> buffers_;
+  std::vector<VkDeviceSize> offsets_;
 };
 
 class CmdDraw : public Cmd {
@@ -133,6 +174,74 @@ class CmdDrawIndexed : public Cmd {
   uint32_t first_index_;
   int32_t vertex_offset_;
   uint32_t first_instance_;
+};
+
+class CmdPipelineBarrier : public Cmd {
+ public:
+  CmdPipelineBarrier(VkPipelineStageFlags src_stage_mask,
+                     VkPipelineStageFlags dst_stage_mask,
+                     VkDependencyFlags dependency_flags,
+                     uint32_t memory_barrier_count,
+                     const VkMemoryBarrier* memory_barriers,
+                     uint32_t buffer_memory_barrier_count,
+                     const VkBufferMemoryBarrier* buffer_memory_barriers,
+                     uint32_t image_memory_barrier_count,
+                     const VkImageMemoryBarrier* image_memory_barriers)
+      : src_stage_mask_(src_stage_mask),
+        dst_stage_mask_(dst_stage_mask),
+        dependency_flags_(dependency_flags) {
+    // Copy the memory barriers to vectors for easier access.
+    if (memory_barrier_count > 0) {
+      absl::Span<const VkMemoryBarrier> span =
+          absl::MakeConstSpan<>(memory_barriers, memory_barrier_count);
+      memory_barriers_.assign(span.begin(), span.end());
+    }
+    if (buffer_memory_barrier_count > 0) {
+      absl::Span<const VkBufferMemoryBarrier> span = absl::MakeConstSpan<>(
+          buffer_memory_barriers, buffer_memory_barrier_count);
+      buffer_memory_barriers_.assign(span.begin(), span.end());
+    }
+    if (image_memory_barrier_count > 0) {
+      absl::Span<const VkImageMemoryBarrier> span = absl::MakeConstSpan<>(
+          image_memory_barriers, image_memory_barrier_count);
+      image_memory_barriers_.assign(span.begin(), span.end());
+    }
+  }
+
+  // Sets the index buffer binding.
+  void ProcessSubmittedCommand(
+      DrawCallTracker* draw_call_state_tracker) override;
+
+  // Getters for the member fields.
+
+  [[nodiscard]] VkPipelineStageFlags GetSrcStageMask() const {
+    return src_stage_mask_;
+  }
+  [[nodiscard]] VkPipelineStageFlags GetDstStageMask() const {
+    return dst_stage_mask_;
+  }
+  [[nodiscard]] VkDependencyFlags GetDependencyFlags() const {
+    return dependency_flags_;
+  }
+  [[nodiscard]] const std::vector<VkMemoryBarrier>& GetMemoryBarriers() const {
+    return memory_barriers_;
+  }
+  [[nodiscard]] const std::vector<VkBufferMemoryBarrier>&
+  GetBufferMemoryBarriers() const {
+    return buffer_memory_barriers_;
+  }
+  [[nodiscard]] const std::vector<VkImageMemoryBarrier>&
+  GetImageMemoryBarriers() const {
+    return image_memory_barriers_;
+  }
+
+ private:
+  VkPipelineStageFlags src_stage_mask_;
+  VkPipelineStageFlags dst_stage_mask_;
+  VkDependencyFlags dependency_flags_;
+  std::vector<VkMemoryBarrier> memory_barriers_;
+  std::vector<VkBufferMemoryBarrier> buffer_memory_barriers_;
+  std::vector<VkImageMemoryBarrier> image_memory_barriers_;
 };
 
 #pragma clang diagnostic pop

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_commands.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_commands.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "VkLayer_GF_amber_scoop/vk_deep_copy.h"
-#include "absl/types/span.h"
 
 namespace gf_layers::amber_scoop_layer {
 
@@ -110,14 +109,11 @@ class CmdBindVertexBuffers : public Cmd {
  public:
   CmdBindVertexBuffers(uint32_t first_binding, uint32_t binding_count,
                        const VkBuffer* buffers, const VkDeviceSize* offsets)
-      : first_binding_(first_binding) {
-    absl::Span<const VkBuffer> buffer_span =
-        absl::MakeConstSpan<>(buffers, binding_count);
-    absl::Span<const VkDeviceSize> offsets_span =
-        absl::MakeConstSpan<>(offsets, binding_count);
-    buffers_.assign(buffer_span.begin(), buffer_span.end());
-    offsets_.assign(offsets_span.begin(), offsets_span.end());
-  }
+      : first_binding_(first_binding),
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        buffers_(buffers, buffers + binding_count),
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        offsets_(offsets, offsets + binding_count) {}
 
   // Sets vertex buffer bindings and their offsets.
   void ProcessSubmittedCommand(
@@ -190,21 +186,24 @@ class CmdPipelineBarrier : public Cmd {
       : src_stage_mask_(src_stage_mask),
         dst_stage_mask_(dst_stage_mask),
         dependency_flags_(dependency_flags) {
-    // Copy the memory barriers to vectors for easier access.
+    // Copy the barriers to vectors for easier access.
     if (memory_barrier_count > 0) {
-      absl::Span<const VkMemoryBarrier> span =
-          absl::MakeConstSpan<>(memory_barriers, memory_barrier_count);
-      memory_barriers_.assign(span.begin(), span.end());
+      memory_barriers_.assign(
+          memory_barriers,
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          memory_barriers + memory_barrier_count);
     }
     if (buffer_memory_barrier_count > 0) {
-      absl::Span<const VkBufferMemoryBarrier> span = absl::MakeConstSpan<>(
-          buffer_memory_barriers, buffer_memory_barrier_count);
-      buffer_memory_barriers_.assign(span.begin(), span.end());
+      buffer_memory_barriers_.assign(
+          buffer_memory_barriers,
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          buffer_memory_barriers + buffer_memory_barrier_count);
     }
     if (image_memory_barrier_count > 0) {
-      absl::Span<const VkImageMemoryBarrier> span = absl::MakeConstSpan<>(
-          image_memory_barriers, image_memory_barrier_count);
-      image_memory_barriers_.assign(span.begin(), span.end());
+      image_memory_barriers_.assign(
+          image_memory_barriers,
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          image_memory_barriers + image_memory_barrier_count);
     }
   }
 

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_commands.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_commands.h
@@ -15,13 +15,13 @@
 #ifndef VKLAYER_GF_AMBER_SCOOP_VULKAN_COMMANDS_H
 #define VKLAYER_GF_AMBER_SCOOP_VULKAN_COMMANDS_H
 
-#include <absl/types/span.h>
 #include <vulkan/vulkan.h>
 
 #include <cstdint>
 #include <vector>
 
 #include "VkLayer_GF_amber_scoop/vk_deep_copy.h"
+#include "absl/types/span.h"
 
 namespace gf_layers::amber_scoop_layer {
 

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_util.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_util.h
@@ -1,0 +1,42 @@
+// Copyright 2020 The gf-layers Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VKLAYER_GF_AMBER_SCOOP_VULKAN_UTIL_H
+#define VKLAYER_GF_AMBER_SCOOP_VULKAN_UTIL_H
+
+#include <vulkan/vulkan_core.h>
+
+#include "gf_layers_layer_util/logging.h"
+
+namespace gf_layers::amber_scoop_layer {
+
+// Helper function for checking return value of any Vulkan command that returns
+// |VkResult|. Asserts if the command fails.
+inline void RequireSuccess(VkResult result) {
+  RUNTIME_ASSERT(VK_SUCCESS == result);
+}
+
+// Helper function for checking return value of any Vulkan command that returns
+// |VkResult| and also logs the given |error_message| if the command fails.
+// Asserts if the command fails.
+inline void RequireSuccess(VkResult result, const char* error_message) {
+  if (VK_SUCCESS != result) {
+    LOG("%s", error_message);
+    RUNTIME_ASSERT(false);
+  }
+}
+
+}  // namespace gf_layers::amber_scoop_layer
+
+#endif  // VKLAYER_GF_AMBER_SCOOP_VULKAN_UTIL_H

--- a/src/VkLayer_GF_amber_scoop/src/amber_scoop_layer.cc
+++ b/src/VkLayer_GF_amber_scoop/src/amber_scoop_layer.cc
@@ -50,6 +50,11 @@ GlobalData global_data_;  // NOLINT(cert-err58-cpp)
 
 GlobalData* GetGlobalData() { return &global_data_; }
 
+inline DeviceData* GetDeviceData(void* device_key) {
+  GlobalData* global_data = &global_data_;
+  return global_data->device_map.Get(device_key)->get();
+}
+
 const std::array<VkLayerProperties, 1> kLayerProperties{{{
     "VkLayer_GF_amber_scoop",       // layerName
     VK_MAKE_VERSION(1U, 1U, 130U),  // specVersion NOLINT(hicpp-signed-bitwise)
@@ -89,13 +94,8 @@ void AddCommand(DeviceData* device_data, VkCommandBuffer command_buffer,
                 std::unique_ptr<Cmd> command) {
   auto* tracked_command_buffer =
       device_data->command_buffers_data.Get(command_buffer);
-  // Check if the command buffer isn't tracked and start tracking if it isn't
-  // tracked.
-  if (tracked_command_buffer == nullptr) {
-    device_data->command_buffers_data.Put(command_buffer, CommandBufferData());
-    tracked_command_buffer =
-        device_data->command_buffers_data.Get(command_buffer);
-  }
+  // All of the command buffers should be tracked.
+  DEBUG_ASSERT(tracked_command_buffer != nullptr);
   tracked_command_buffer->AddCommand(std::move(command));
 }
 
@@ -119,6 +119,24 @@ VKAPI_ATTR void VKAPI_CALL vkCmdBeginRenderPass(
 }
 
 //
+// Our vkCmdBindIndexBuffer function.
+//
+VKAPI_ATTR void VKAPI_CALL vkCmdBindIndexBuffer(VkCommandBuffer commandBuffer,
+                                                VkBuffer buffer,
+                                                VkDeviceSize offset,
+                                                VkIndexType indexType) {
+  GlobalData* global_data = GetGlobalData();
+  DeviceData* device_data =
+      global_data->device_map.Get(DeviceKey(commandBuffer))->get();
+
+  // Call the original function.
+  device_data->vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
+
+  AddCommand(device_data, commandBuffer,
+             std::make_unique<CmdBindIndexBuffer>(buffer, offset, indexType));
+}
+
+//
 // Our vkCmdBindPipeline function.
 //
 VKAPI_ATTR void VKAPI_CALL
@@ -133,6 +151,24 @@ vkCmdBindPipeline(VkCommandBuffer commandBuffer,
 
   AddCommand(device_data, commandBuffer,
              std::make_unique<CmdBindPipeline>(pipelineBindPoint, pipeline));
+}
+
+//
+// Our vkCmdBindVertexBuffers function.
+//
+VKAPI_ATTR void VKAPI_CALL vkCmdBindVertexBuffers(
+    VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
+    VkBuffer const* pBuffers, VkDeviceSize const* pOffsets) {
+  GlobalData* global_data = GetGlobalData();
+  DeviceData* device_data =
+      global_data->device_map.Get(DeviceKey(commandBuffer))->get();
+
+  // Call the original function.
+  device_data->vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount,
+                                      pBuffers, pOffsets);
+  AddCommand(device_data, commandBuffer,
+             std::make_unique<CmdBindVertexBuffers>(firstBinding, bindingCount,
+                                                    pBuffers, pOffsets));
 }
 
 //
@@ -176,7 +212,123 @@ VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexed(
                                        vertexOffset, firstInstance));
 }
 
+//
+// Our vkCmdPipelineBarrier function.
+//
+void vkCmdPipelineBarrier(VkCommandBuffer commandBuffer,
+                          VkPipelineStageFlags srcStageMask,
+                          VkPipelineStageFlags dstStageMask,
+                          VkDependencyFlags dependencyFlags,
+                          uint32_t memoryBarrierCount,
+                          VkMemoryBarrier const* pMemoryBarriers,
+                          uint32_t bufferMemoryBarrierCount,
+                          VkBufferMemoryBarrier const* pBufferMemoryBarriers,
+                          uint32_t imageMemoryBarrierCount,
+                          VkImageMemoryBarrier const* pImageMemoryBarriers) {
+  GlobalData* global_data = GetGlobalData();
+  DeviceData* device_data =
+      global_data->device_map.Get(DeviceKey(commandBuffer))->get();
+
+  // Call the original function.
+  device_data->vkCmdPipelineBarrier(
+      commandBuffer, srcStageMask, dstStageMask, dependencyFlags,
+      memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount,
+      pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+
+  AddCommand(
+      device_data, commandBuffer,
+      std::make_unique<CmdPipelineBarrier>(
+          srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount,
+          pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
+          imageMemoryBarrierCount, pImageMemoryBarriers));
+}
+
 // Other intercepted vulkan functions.
+
+//
+// Our vkAllocateCommandBuffers function.
+//
+VKAPI_ATTR VkResult VKAPI_CALL vkAllocateCommandBuffers(
+    VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
+    VkCommandBuffer* pCommandBuffers) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  auto result = device_data->vkAllocateCommandBuffers(device, pAllocateInfo,
+                                                      pCommandBuffers);
+  if (result == VK_SUCCESS) {
+    for (uint32_t i = 0; i < pAllocateInfo->commandBufferCount; i++) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      device_data->command_buffers_data.Put(pCommandBuffers[i],
+                                            CommandBufferData(*pAllocateInfo));
+    }
+  }
+  return result;
+}
+
+//
+// Our vkFreeCommandBuffers function.
+//
+void vkFreeCommandBuffers(VkDevice device, VkCommandPool commandPool,
+                          uint32_t commandBufferCount,
+                          const VkCommandBuffer* pCommandBuffers) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  device_data->vkFreeCommandBuffers(device, commandPool, commandBufferCount,
+                                    pCommandBuffers);
+
+  for (uint32_t i = 0; i < commandBufferCount; i++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    device_data->command_buffers_data.Remove(pCommandBuffers[i]);
+  }
+}
+
+//
+// Our vkCreateBuffer function.
+//
+VKAPI_ATTR VkResult VKAPI_CALL
+vkCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
+               const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  VkBufferCreateInfo create_info = *pCreateInfo;
+  // Allow vertex/index/uniform/storage buffer to be used as transfer source
+  // buffer. Required if the buffer data needs to be copied from the buffer.
+  // NOLINTNEXTLINE(hicpp-signed-bitwise)
+  if ((create_info.usage &
+       // NOLINTNEXTLINE(hicpp-signed-bitwise)
+       (VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT |
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT |
+        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+        VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT |
+        VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT)) != 0) {
+    create_info.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+  }
+
+  // Call the original function with the modified create info.
+  VkResult result =
+      device_data->vkCreateBuffer(device, &create_info, pAllocator, pBuffer);
+
+  if (result == VK_SUCCESS) {
+    device_data->buffers.Put(*pBuffer, BufferData(create_info));
+  }
+
+  return result;
+}
+
+//
+// Our vkDestroyBuffer function.
+//
+void vkDestroyBuffer(VkDevice device, VkBuffer buffer,
+                     const VkAllocationCallbacks* pAllocator) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  device_data->vkDestroyBuffer(device, buffer, pAllocator);
+
+  device_data->buffers.Remove(buffer);
+}
 
 //
 // Our vkCreateGraphicsPipelines function.
@@ -185,9 +337,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(
     VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
     const VkGraphicsPipelineCreateInfo* pCreateInfos,
     const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) {
-  GlobalData* global_data = GetGlobalData();
-  DeviceData* device_data =
-      global_data->device_map.Get(DeviceKey(device))->get();
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
 
   // Call the original function.
   VkResult result = device_data->vkCreateGraphicsPipelines(
@@ -238,9 +388,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateShaderModule(
     VkDevice device, VkShaderModuleCreateInfo const* pCreateInfo,
     VkAllocationCallbacks const* pAllocator, VkShaderModule* pShaderModule) {
-  GlobalData* global_data = GetGlobalData();
-  DeviceData* device_data =
-      global_data->device_map.Get(DeviceKey(device))->get();
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
 
   auto result = device_data->vkCreateShaderModule(device, pCreateInfo,
                                                   pAllocator, pShaderModule);
@@ -258,9 +406,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateShaderModule(
 //
 void vkDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
                            VkAllocationCallbacks const* pAllocator) {
-  GlobalData* global_data = GetGlobalData();
-  DeviceData* device_data =
-      global_data->device_map.Get(DeviceKey(device))->get();
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
 
   // Call the original function.
   device_data->vkDestroyShaderModule(device, shaderModule, pAllocator);
@@ -466,6 +612,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(
 
   HANDLE(vkGetInstanceProcAddr)
   HANDLE(vkEnumerateDeviceExtensionProperties)
+  HANDLE(vkGetPhysicalDeviceMemoryProperties)
 #undef HANDLE
 
   DEBUG_ASSERT(next_get_instance_proc_address ==
@@ -535,6 +682,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(
 
   std::unique_ptr<DeviceData> device_data = std::make_unique<DeviceData>();
 
+  device_data->physical_device = physicalDevice;
   device_data->device = *pDevice;
   device_data->instance_data = instance_data;
 
@@ -545,15 +693,38 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(
     return VK_ERROR_INITIALIZATION_FAILED;            \
   }
 
+  HANDLE(vkAllocateCommandBuffers)
+  HANDLE(vkFreeCommandBuffers)
+  HANDLE(vkCreateBuffer)
+  HANDLE(vkDestroyBuffer)
   HANDLE(vkCreateGraphicsPipelines)
   HANDLE(vkCreateShaderModule)
   HANDLE(vkDestroyShaderModule)
   HANDLE(vkGetDeviceProcAddr)
   HANDLE(vkQueueSubmit)
   HANDLE(vkCmdBeginRenderPass)
+  HANDLE(vkCmdBindIndexBuffer)
   HANDLE(vkCmdBindPipeline)
+  HANDLE(vkCmdBindVertexBuffers)
   HANDLE(vkCmdDraw)
   HANDLE(vkCmdDrawIndexed)
+  HANDLE(vkCmdPipelineBarrier)
+
+  // Functions used by the layer but not intercepted:
+  HANDLE(vkAllocateMemory)
+  HANDLE(vkFreeMemory)
+  HANDLE(vkBeginCommandBuffer)
+  HANDLE(vkEndCommandBuffer)
+  HANDLE(vkBindBufferMemory)
+  HANDLE(vkCmdCopyBuffer)
+  HANDLE(vkCreateFence)
+  HANDLE(vkDestroyFence)
+  HANDLE(vkGetBufferMemoryRequirements)
+  HANDLE(vkInvalidateMappedMemoryRanges)
+  HANDLE(vkMapMemory)
+  HANDLE(vkQueueWaitIdle)
+  HANDLE(vkUnmapMemory)
+  HANDLE(vkWaitForFences)
 
 #undef HANDLE
 
@@ -584,14 +755,21 @@ vkGetDeviceProcAddr(VkDevice device, const char* pName) {
   HANDLE(vkGetDeviceProcAddr)  // Self-reference.
 
   // Other device functions that this layer intercepts:
+  HANDLE(vkAllocateCommandBuffers)
+  HANDLE(vkFreeCommandBuffers)
+  HANDLE(vkCreateBuffer)
+  HANDLE(vkDestroyBuffer)
   HANDLE(vkCreateGraphicsPipelines)
   HANDLE(vkCreateShaderModule)
   HANDLE(vkDestroyShaderModule)
   HANDLE(vkQueueSubmit)
   HANDLE(vkCmdBeginRenderPass)
+  HANDLE(vkCmdBindIndexBuffer)
   HANDLE(vkCmdBindPipeline)
+  HANDLE(vkCmdBindVertexBuffers)
   HANDLE(vkCmdDraw)
   HANDLE(vkCmdDrawIndexed)
+  HANDLE(vkCmdPipelineBarrier)
 #undef HANDLE
 
   if (device == nullptr) {

--- a/src/VkLayer_GF_amber_scoop/src/buffer_copy.cc
+++ b/src/VkLayer_GF_amber_scoop/src/buffer_copy.cc
@@ -91,13 +91,14 @@ BufferCopy::BufferCopy(DeviceData* device_data, const VkBuffer& buffer,
   memory_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
   memory_barrier.pNext = nullptr;
   memory_barrier.srcAccessMask =
-      VK_ACCESS_HOST_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+      VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+      VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_HOST_WRITE_BIT;
   memory_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
 
   device_data_->vkCmdPipelineBarrier(
       command_buffer,                      // commandBuffer
-      VK_PIPELINE_STAGE_HOST_BIT |         //
-          VK_PIPELINE_STAGE_TRANSFER_BIT,  // srcStageMask
+      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,  // srcStageMask
       VK_PIPELINE_STAGE_TRANSFER_BIT,      // dstStageMask
       0,                                   // dependencyFlags
       1U,                                  // memoryBarrierCount

--- a/src/VkLayer_GF_amber_scoop/src/buffer_copy.cc
+++ b/src/VkLayer_GF_amber_scoop/src/buffer_copy.cc
@@ -1,0 +1,204 @@
+// Copyright 2020 The gf-layers Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "VkLayer_GF_amber_scoop/buffer_copy.h"
+
+#include <VkLayer_GF_amber_scoop/vulkan_util.h>
+
+#include "gf_layers_layer_util/logging.h"
+
+namespace gf_layers::amber_scoop_layer {
+
+BufferCopy::BufferCopy(
+    DeviceData* device_data, const VkBuffer& buffer, VkDeviceSize buffer_size,
+    VkQueue queue, VkCommandPool command_pool,
+    const std::vector<const CmdPipelineBarrier*>& pipeline_barriers)
+    : device_data_(device_data) {
+  VkDevice device = device_data_->device;
+
+  // Create a buffer where the data will be copied to.
+  {
+    VkBufferCreateInfo create_info = {};
+    create_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    create_info.size = buffer_size;
+    create_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    RequireSuccess(device_data_->vkCreateBuffer(device, &create_info, nullptr,
+                                                &buffer_copy_),
+                   "Failed to create buffer for the copied data.");
+  }
+
+  VkMemoryRequirements memory_requirements;
+  device_data_->vkGetBufferMemoryRequirements(device, buffer_copy_,
+                                              &memory_requirements);
+  {
+    VkMemoryAllocateInfo vkMemoryAllocateInfo = {};
+    vkMemoryAllocateInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    vkMemoryAllocateInfo.allocationSize = memory_requirements.size;
+    vkMemoryAllocateInfo.memoryTypeIndex =
+        FindMemoryType(memory_requirements.memoryTypeBits,
+                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    RequireSuccess(
+        device_data_->vkAllocateMemory(device, &vkMemoryAllocateInfo, nullptr,
+                                       &buffer_copy_memory_),
+        "Failed to allocate memory for buffer copy.");
+  }
+  RequireSuccess(device_data_->vkBindBufferMemory(device, buffer_copy_,
+                                                  buffer_copy_memory_, 0),
+                 "Failed binding memory for buffer copy.");
+
+  // Create command buffer
+  VkCommandBuffer command_buffer = nullptr;
+  VkCommandBufferAllocateInfo command_buffer_allocate_info = {};
+  command_buffer_allocate_info.sType =
+      VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+  command_buffer_allocate_info.commandPool = command_pool;
+  command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+  command_buffer_allocate_info.commandBufferCount = 1;
+  RequireSuccess(device_data_->vkAllocateCommandBuffers(
+                     device, &command_buffer_allocate_info, &command_buffer),
+                 "Failed to allocate command buffers.");
+
+  // Record a command buffer for the copy operation.
+  VkCommandBufferBeginInfo begin_info = {};
+  begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+
+  RequireSuccess(
+      device_data_->vkBeginCommandBuffer(command_buffer, &begin_info),
+      "Failed to begin command buffer.");
+
+  // Copy all global and buffer memory barriers. Set
+  // VK_ACCESS_TRANSFER_READ_BIT for copied (buffer)memory barriers, so we can
+  // execute a copy operation.
+  for (const auto& pipeline_barrier : pipeline_barriers) {
+    auto buffer_memory_barriers = std::vector<VkBufferMemoryBarrier>(
+        pipeline_barrier->GetBufferMemoryBarriers());
+    auto memory_barriers =
+        std::vector<VkMemoryBarrier>(pipeline_barrier->GetMemoryBarriers());
+
+    // Set dstAccessMask(s) to VK_ACCESS_TRANSFER_READ_BIT
+    for (auto& buffer_memory_barrier : buffer_memory_barriers) {
+      buffer_memory_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    }
+    for (auto& memory_barrier : memory_barriers) {
+      memory_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    }
+
+    // clang-format off
+    device_data_->vkCmdPipelineBarrier(
+        command_buffer,
+        pipeline_barrier->GetSrcStageMask(),
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        0,
+        static_cast<uint32_t>(memory_barriers.size()),
+        memory_barriers.data(),
+        static_cast<uint32_t>(buffer_memory_barriers.size()),
+        buffer_memory_barriers.data(),
+        0,
+        nullptr);
+    // clang-format on
+  }
+
+  // Copy buffer
+  VkBufferCopy copy_region = {0, 0, buffer_size};
+  device_data_->vkCmdCopyBuffer(command_buffer, buffer, buffer_copy_, 1,
+                                &copy_region);
+
+  // Memory barrier for making sure we can safely read the copied data from
+  // the host.
+  VkMemoryBarrier host_copy_barrier = {};
+  host_copy_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+  host_copy_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+  host_copy_barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+  // clang-format off
+  device_data_->vkCmdPipelineBarrier(
+      command_buffer,
+      VK_PIPELINE_STAGE_TRANSFER_BIT,
+      VK_PIPELINE_STAGE_HOST_BIT,
+      0,
+      1,
+      &host_copy_barrier,
+      0,
+      nullptr,
+      0,
+      nullptr);
+  // clang-format on
+
+  RequireSuccess(device_data_->vkEndCommandBuffer(command_buffer),
+                 "Failed to record command buffer.");
+
+  // Submit commands and wait for commands to be executed.
+  {
+    VkFence fence = nullptr;
+    VkFenceCreateInfo create_info = {};
+    create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    create_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+    device_data->vkCreateFence(device, &create_info, nullptr, &fence);
+
+    VkSubmitInfo submit_info = {};
+    submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &command_buffer;
+    device_data_->vkQueueSubmit(queue, 1, &submit_info, fence);
+    device_data_->vkWaitForFences(device, 1, &fence, VK_FALSE, ~0ULL);
+  }
+
+  // Invalidate memory to make it host visible.
+  {
+    RequireSuccess(device_data_->vkMapMemory(device, buffer_copy_memory_, 0,
+                                             buffer_size, 0, &copied_data_),
+                   "Failed to map memory.");
+    VkMappedMemoryRange range_to_invalidate = {};
+    range_to_invalidate.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+    range_to_invalidate.memory = buffer_copy_memory_;
+    range_to_invalidate.offset = 0;
+    range_to_invalidate.size = VK_WHOLE_SIZE;
+    RequireSuccess(device_data_->vkInvalidateMappedMemoryRanges(
+                       device, 1, &range_to_invalidate),
+                   "Failed to unmap memory.");
+  }
+
+  // Free resources
+  device_data_->vkFreeCommandBuffers(device_data_->device, command_pool, 1,
+                                     &command_buffer);
+}
+
+BufferCopy::~BufferCopy() {
+  // Unmap memory, free the memory and destroy the buffer.
+  device_data_->vkUnmapMemory(device_data_->device, buffer_copy_memory_);
+  device_data_->vkFreeMemory(device_data_->device, buffer_copy_memory_,
+                             nullptr);
+  device_data_->vkDestroyBuffer(device_data_->device, buffer_copy_, nullptr);
+}
+
+uint32_t BufferCopy::FindMemoryType(uint32_t memory_type_bits,
+                                    VkMemoryPropertyFlags required_properties) {
+  VkPhysicalDeviceMemoryProperties memory_properties;
+  device_data_->instance_data->vkGetPhysicalDeviceMemoryProperties(
+      device_data_->physical_device, &memory_properties);
+
+  for (uint32_t idx = 0; idx < memory_properties.memoryTypeCount; idx++) {
+    if ((memory_type_bits & (1U << idx)) != 0 &&
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+        (memory_properties.memoryTypes[idx].propertyFlags &
+         required_properties) == required_properties) {
+      return idx;
+    }
+  }
+  LOG("Failed to find suitable memory type.");
+  RUNTIME_ASSERT(false);
+}
+
+}  // namespace gf_layers::amber_scoop_layer

--- a/src/VkLayer_GF_amber_scoop/src/buffer_copy.cc
+++ b/src/VkLayer_GF_amber_scoop/src/buffer_copy.cc
@@ -171,8 +171,8 @@ BufferCopy::BufferCopy(
   }
 
   // Create a span for the copied data so it can be accessed more safely.
-  copied_data_span_ = absl::MakeConstSpan<>(
-      reinterpret_cast<char*>(copied_data_), buffer_size);
+  copied_data_span_ =
+      absl::MakeConstSpan<>(reinterpret_cast<char*>(copied_data_), buffer_size);
 
   // Free resources
   device_data_->vkFreeCommandBuffers(device_data_->device, command_pool, 1,

--- a/src/VkLayer_GF_amber_scoop/src/command_buffer_data.cc
+++ b/src/VkLayer_GF_amber_scoop/src/command_buffer_data.cc
@@ -24,18 +24,16 @@
 namespace gf_layers::amber_scoop_layer {
 
 void CommandBufferData::AddCommand(std::unique_ptr<Cmd> cmd) {
-  // Command buffer must be reset if it has been submitted and new commands
-  // are being added to it, so we reset our command buffer tracker.
-  if (is_submitted_) {
-    command_list.clear();
-    is_submitted_ = false;
-    contains_draw_calls_ = false;
-  }
   // Set the flag if the command being added is a draw call.
   if (cmd->IsDrawCall()) {
     contains_draw_calls_ = true;
   }
   command_list.push_back(std::move(cmd));
+}
+
+void CommandBufferData::ResetState() {
+  command_list.clear();
+  contains_draw_calls_ = false;
 }
 
 }  // namespace gf_layers::amber_scoop_layer

--- a/src/VkLayer_GF_amber_scoop/src/command_buffer_data.cc
+++ b/src/VkLayer_GF_amber_scoop/src/command_buffer_data.cc
@@ -14,6 +14,8 @@
 
 #include "VkLayer_GF_amber_scoop/command_buffer_data.h"
 
+// <algorithm> is used by GCC's libstdc++, but not LLVM's libc++.
+#include <algorithm>  // IWYU pragma: keep
 #include <memory>
 #include <utility>
 

--- a/src/VkLayer_GF_amber_scoop/src/draw_call_tracker.cc
+++ b/src/VkLayer_GF_amber_scoop/src/draw_call_tracker.cc
@@ -224,14 +224,16 @@ void DrawCallTracker::CreateIndexBufferDeclarations(
     DeviceData* device_data, uint32_t index_count,
     std::ostringstream& declaration_string_stream,
     std::ostringstream& pipeline_string_stream) {
-  auto* index_buffer = draw_call_state_.bound_index_buffer.buffer;
-  auto* buffer_create_info = device_data->buffers.Get(index_buffer);
+  VkBuffer index_buffer = draw_call_state_.bound_index_buffer.buffer;
+  BufferData* buffer_create_info = device_data->buffers.Get(index_buffer);
 
-  // Get the command pool used to create th current command buffer. Command pool
-  // is used to create our own command buffer for copying the buffer contents.
+  // Get the command pool used to create the current command buffer. The command
+  // pool is used to create our own command buffer for copying the buffer
+  // contents.
   CommandBufferData* command_buffer_data =
       device_data->command_buffers_data.Get(draw_call_state_.command_buffer);
-  auto* command_pool = command_buffer_data->GetAllocateInfo()->commandPool;
+  VkCommandPool command_pool =
+      command_buffer_data->GetAllocateInfo()->commandPool;
 
   // Create a list of pipeline barriers that should be used to synchronize
   // the access to index buffer.
@@ -239,11 +241,10 @@ void DrawCallTracker::CreateIndexBufferDeclarations(
 
   // List of stage flags we are interested in.
   static const VkPipelineStageFlags stages_flag_bits =
-      // NOLINTNEXTLINE(hicpp-signed-bitwise)
       VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT |
       VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT;
 
-  // Copy all barriers that has any of the above stage flags set as
+  // Copy all barriers that have any of the above stage flags set as
   // |dstStageMask|.
   std::copy_if(draw_call_state_.pipeline_barriers.begin(),
                draw_call_state_.pipeline_barriers.end(),
@@ -275,7 +276,7 @@ void DrawCallTracker::CreateIndexBufferDeclarations(
     // 16-bit indices
     // Create a new span with type of |uint16_t| so the indices can be read
     // easily.
-    absl::Span<const uint16_t> index_data = absl::MakeConstSpan<>(
+    absl::Span<const uint16_t> index_data = absl::MakeConstSpan(
         reinterpret_cast<const uint16_t*>(first_index_address), index_count);
     // Append values to the index buffer string.
     for (uint16_t index : index_data) {
@@ -286,7 +287,7 @@ void DrawCallTracker::CreateIndexBufferDeclarations(
     // 32-bit indices
     // Create a new span with type of |uint32_t| so the indices can be read
     // easily.
-    absl::Span<const uint32_t> index_data = absl::MakeConstSpan<>(
+    absl::Span<const uint32_t> index_data = absl::MakeConstSpan(
         reinterpret_cast<const uint32_t*>(first_index_address), index_count);
     // Append values to the index buffer string.
     for (uint32_t index : index_data) {

--- a/src/VkLayer_GF_amber_scoop/src/vk_deep_copy.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vk_deep_copy.cc
@@ -18,6 +18,20 @@
 
 namespace gf_layers::amber_scoop_layer {
 
+VkBufferCreateInfo DeepCopy(const VkBufferCreateInfo& create_info) {
+  VkBufferCreateInfo result = create_info;
+  result.pQueueFamilyIndices = CopyArray(create_info.pQueueFamilyIndices,
+                                         create_info.queueFamilyIndexCount);
+  return result;
+}
+
+void DeepDelete(const VkBufferCreateInfo& create_info) {
+  if (create_info.queueFamilyIndexCount > 0) {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    delete[] create_info.pQueueFamilyIndices;
+  }
+}
+
 VkGraphicsPipelineCreateInfo DeepCopy(
     const VkGraphicsPipelineCreateInfo& create_info) {
   VkGraphicsPipelineCreateInfo result = create_info;

--- a/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
@@ -14,7 +14,7 @@
 
 #include "VkLayer_GF_amber_scoop/vulkan_commands.h"
 
-#include <VkLayer_GF_amber_scoop/draw_call_tracker.h>
+#include "VkLayer_GF_amber_scoop/draw_call_tracker.h"
 
 // <algorithm> is used by GCC's libstdc++, but not LLVM's libc++.
 #include <algorithm>  // IWYU pragma: keep

--- a/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
@@ -16,6 +16,8 @@
 
 #include <VkLayer_GF_amber_scoop/draw_call_tracker.h>
 
+// <algorithm> is used by GCC's libstdc++, but not LLVM's libc++.
+#include <algorithm>  // IWYU pragma: keep
 #include <unordered_map>
 
 namespace gf_layers::amber_scoop_layer {

--- a/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
@@ -14,11 +14,11 @@
 
 #include "VkLayer_GF_amber_scoop/vulkan_commands.h"
 
-#include "VkLayer_GF_amber_scoop/draw_call_tracker.h"
-
-// <algorithm> is used by GCC's libstdc++, but not LLVM's libc++.
 #include <algorithm>  // IWYU pragma: keep
+// <algorithm> is used by GCC's libstdc++, but not LLVM's libc++.
 #include <unordered_map>
+
+#include "VkLayer_GF_amber_scoop/draw_call_tracker.h"
 
 namespace gf_layers::amber_scoop_layer {
 

--- a/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
@@ -16,6 +16,8 @@
 
 #include <VkLayer_GF_amber_scoop/draw_call_tracker.h>
 
+#include <unordered_map>
+
 namespace gf_layers::amber_scoop_layer {
 
 Cmd::Cmd() = default;
@@ -30,11 +32,34 @@ void CmdBeginRenderPass::ProcessSubmittedCommand(
   draw_call_state_tracker->GetDrawCallState()->current_subpass = 0;
 }
 
+void CmdBindIndexBuffer::ProcessSubmittedCommand(
+    DrawCallTracker* draw_call_state_tracker) {
+  auto& bound_index_buffer =
+      draw_call_state_tracker->GetDrawCallState()->bound_index_buffer;
+
+  bound_index_buffer.buffer = buffer_;
+  bound_index_buffer.offset = offset_;
+  bound_index_buffer.index_type = index_type_;
+}
+
 void CmdBindPipeline::ProcessSubmittedCommand(
     DrawCallTracker* draw_call_state_tracker) {
   // Currently we are interested in graphics pipelines only.
   if (pipeline_bind_point_ == VK_PIPELINE_BIND_POINT_GRAPHICS) {
     draw_call_state_tracker->GetDrawCallState()->graphics_pipeline = pipeline_;
+  }
+}
+
+void CmdBindVertexBuffers::ProcessSubmittedCommand(
+    DrawCallTracker* draw_call_state_tracker) {
+  // Set vertex buffer bindings and their offsets.
+
+  auto& bound_vertex_buffers =
+      draw_call_state_tracker->GetDrawCallState()->bound_vertex_buffers;
+
+  for (uint32_t binding_idx = 0; binding_idx < buffers_.size(); binding_idx++) {
+    bound_vertex_buffers[binding_idx + first_binding_] = {
+        buffers_[binding_idx], offsets_[binding_idx]};
   }
 }
 
@@ -48,6 +73,12 @@ void CmdDrawIndexed::ProcessSubmittedCommand(
     DrawCallTracker* draw_call_state_tracker) {
   draw_call_state_tracker->HandleDrawCall(first_index_, index_count_, 0, 0,
                                           first_instance_, instance_count_);
+}
+
+void CmdPipelineBarrier::ProcessSubmittedCommand(
+    DrawCallTracker* draw_call_state_tracker) {
+  draw_call_state_tracker->GetDrawCallState()->pipeline_barriers.push_back(
+      this);
 }
 
 }  // namespace gf_layers::amber_scoop_layer

--- a/src/VkLayer_GF_frame_counter/src/frame_counter_layer.cc
+++ b/src/VkLayer_GF_frame_counter/src/frame_counter_layer.cc
@@ -105,7 +105,7 @@ GlobalData* GetGlobalData() { return &global_data_; }
 
 const std::array<VkLayerProperties, 1> kLayerProperties{{{
     "VkLayer_GF_frame_counter",     // layerName
-    VK_MAKE_VERSION(1U, 1U, 130U),  // specVersion NOLINT(hicpp-signed-bitwise)
+    VK_MAKE_VERSION(1U, 1U, 130U),  // specVersion
     1,                              // implementationVersion
     "Frame counter layer.",         // description
 }}};

--- a/src/VkLayer_GF_shader_fuzzer/src/shader_fuzzer_layer.cc
+++ b/src/VkLayer_GF_shader_fuzzer/src/shader_fuzzer_layer.cc
@@ -169,7 +169,7 @@ GlobalData* GetGlobalData() { return &global_data_; }
 
 const std::array<VkLayerProperties, 1> kLayerProperties{{{
     "VkLayer_GF_shader_fuzzer",     // layerName
-    VK_MAKE_VERSION(1U, 1U, 130U),  // specVersion NOLINT(hicpp-signed-bitwise)
+    VK_MAKE_VERSION(1U, 1U, 130U),  // specVersion
     1,                              // implementationVersion
     "Shader fuzzer layer.",         // description
 }}};


### PR DESCRIPTION
Captures index buffers and add the indices to the Amber file.

Adds generic class for copying buffers to host visible memory.

vkCmdBindVertexBuffers command is also captured but the vertex
buffers aren't captured yet.

New intercepted Vulkan commands:
- vkAllocateCommandBuffers
- vkFreeCommandBuffers
- vkCreateBuffer
- vkDestroyBuffer
- vkCmdBindIndexBuffer
- vkCmdBindVertexBuffers
- vkCmdPipelineBarrier