### PR TITLE
Fix wrong vk*ProcAddr in dispatch table

### DIFF
--- a/src/VkLayer_GF_amber_scoop/src/amber_scoop_layer.cc
+++ b/src/VkLayer_GF_amber_scoop/src/amber_scoop_layer.cc
@@ -464,12 +464,10 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(
     return VK_ERROR_INITIALIZATION_FAILED;                \
   }
 
-  HANDLE(vkGetInstanceProcAddr)
   HANDLE(vkEnumerateDeviceExtensionProperties)
 #undef HANDLE
 
-  DEBUG_ASSERT(next_get_instance_proc_address ==
-               instance_data.vkGetInstanceProcAddr);
+  instance_data.vkGetInstanceProcAddr = next_get_instance_proc_address;
 
   GetGlobalData()->instance_map.Put(InstanceKey(*pInstance), instance_data);
 
@@ -548,7 +546,6 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(
   HANDLE(vkCreateGraphicsPipelines)
   HANDLE(vkCreateShaderModule)
   HANDLE(vkDestroyShaderModule)
-  HANDLE(vkGetDeviceProcAddr)
   HANDLE(vkQueueSubmit)
   HANDLE(vkCmdBeginRenderPass)
   HANDLE(vkCmdBindPipeline)
@@ -557,8 +554,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(
 
 #undef HANDLE
 
-  DEBUG_ASSERT(next_get_device_proc_address ==
-               device_data->vkGetDeviceProcAddr);
+  device_data->vkGetDeviceProcAddr = next_get_device_proc_address;
 
   GetGlobalData()->device_map.Put(DeviceKey(*pDevice), std::move(device_data));
 

--- a/src/VkLayer_GF_frame_counter/src/frame_counter_layer.cc
+++ b/src/VkLayer_GF_frame_counter/src/frame_counter_layer.cc
@@ -344,12 +344,10 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(
     return VK_ERROR_INITIALIZATION_FAILED;                \
   }
 
-  HANDLE(vkGetInstanceProcAddr)
   HANDLE(vkEnumerateDeviceExtensionProperties)
 #undef HANDLE
 
-  DEBUG_ASSERT(next_get_instance_proc_address ==
-               instance_data.vkGetInstanceProcAddr);
+  instance_data.vkGetInstanceProcAddr = next_get_instance_proc_address;
 
   GetGlobalData()->instance_map.Put(InstanceKey(*pInstance), instance_data);
 
@@ -424,12 +422,11 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(
     return VK_ERROR_INITIALIZATION_FAILED;            \
   }
 
-  HANDLE(vkGetDeviceProcAddr)
   HANDLE(vkQueuePresentKHR)
 
 #undef HANDLE
 
-  DEBUG_ASSERT(next_get_device_proc_address == device_data.vkGetDeviceProcAddr);
+  device_data.vkGetDeviceProcAddr = next_get_device_proc_address;
 
   GetGlobalData()->device_map.Put(DeviceKey(*pDevice), device_data);
 

--- a/src/VkLayer_GF_shader_fuzzer/src/shader_fuzzer_layer.cc
+++ b/src/VkLayer_GF_shader_fuzzer/src/shader_fuzzer_layer.cc
@@ -532,12 +532,10 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(
     return VK_ERROR_INITIALIZATION_FAILED;                \
   }
 
-  HANDLE(vkGetInstanceProcAddr)
   HANDLE(vkEnumerateDeviceExtensionProperties)
 #undef HANDLE
 
-  DEBUG_ASSERT(next_get_instance_proc_address ==
-               instance_data.vkGetInstanceProcAddr);
+  instance_data.vkGetInstanceProcAddr = next_get_instance_proc_address;
 
   GetGlobalData()->instance_map.Put(InstanceKey(*pInstance), instance_data);
 
@@ -612,12 +610,11 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(
     return VK_ERROR_INITIALIZATION_FAILED;            \
   }
 
-  HANDLE(vkGetDeviceProcAddr)
   HANDLE(vkCreateShaderModule)
 
 #undef HANDLE
 
-  DEBUG_ASSERT(next_get_device_proc_address == device_data.vkGetDeviceProcAddr);
+  device_data.vkGetDeviceProcAddr = next_get_device_proc_address;
 
   GetGlobalData()->device_map.Put(DeviceKey(*pDevice), device_data);
 


### PR DESCRIPTION
Use pLayerInfo->pfnNextGetXXProcAddr as dispatch table's
vkXXProcAddr instead of getting the function address from the next
layer.

Fixes #16