### PR TITLE
Capture uniform buffers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,48 +31,21 @@ jobs:
           - Release
         # Manually list various Linux configurations.
         include:
-          # gcc-8
-          - os: ubuntu-16.04
-            config: Debug
-            linux_cc: gcc-8
-            linux_cxx: g++-8
-          - os: ubuntu-16.04
-            config: Release
-            linux_cc: gcc-8
-            linux_cxx: g++-8
           # gcc-9
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             config: Debug
             linux_cc: gcc-9
             linux_cxx: g++-9
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             config: Release
             linux_cc: gcc-9
             linux_cxx: g++-9
-          # clang-6
-          - os: ubuntu-16.04
-            config: Debug
-            linux_cc: clang-6.0
-            linux_cxx: clang++-6.0
-          - os: ubuntu-16.04
-            config: Release
-            linux_cc: clang-6.0
-            linux_cxx: clang++-6.0
-          # clang-8
-          - os: ubuntu-16.04
-            config: Debug
-            linux_cc: clang-8
-            linux_cxx: clang++-8
-          - os: ubuntu-16.04
-            config: Release
-            linux_cc: clang-8
-            linux_cxx: clang++-8
           # clang-9
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             config: Debug
             linux_cc: clang-9
             linux_cxx: clang++-9
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             config: Release
             linux_cc: clang-9
             linux_cxx: clang++-9

--- a/dev_shell.sh.template
+++ b/dev_shell.sh.template
@@ -58,11 +58,12 @@ export PATH
 
 # Get cppcheck.
 
-CCPCHECK_OUT="cppcheck-2.4.1"
+CCPCHECK_OUT="cppcheck-3af3d7fc06f0acfc602cdda94ace273e170788e5"
 
 if test ! -f "${CCPCHECK_OUT}.touch"; then
-  git clone --branch 2.4.1 --depth 1 https://github.com/danmar/cppcheck.git "${CCPCHECK_OUT}"
+  git clone --branch main --depth 1 https://github.com/danmar/cppcheck.git "${CCPCHECK_OUT}"
   pushd "${CCPCHECK_OUT}"
+  git checkout 3af3d7fc06f0acfc602cdda94ace273e170788e5
     mkdir build
     pushd build
       cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./install

--- a/dev_shell.sh.template
+++ b/dev_shell.sh.template
@@ -58,10 +58,10 @@ export PATH
 
 # Get cppcheck.
 
-CCPCHECK_OUT="cppcheck-2.1"
+CCPCHECK_OUT="cppcheck-2.4.1"
 
 if test ! -f "${CCPCHECK_OUT}.touch"; then
-  git clone --branch 2.1 --depth 1 https://github.com/danmar/cppcheck.git "${CCPCHECK_OUT}"
+  git clone --branch 2.4.1 --depth 1 https://github.com/danmar/cppcheck.git "${CCPCHECK_OUT}"
   pushd "${CCPCHECK_OUT}"
     mkdir build
     pushd build

--- a/src/VkLayer_GF_amber_scoop/CMakeLists.txt
+++ b/src/VkLayer_GF_amber_scoop/CMakeLists.txt
@@ -18,6 +18,7 @@ set(VkLayer_GF_amber_scoop_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/command_buffer_data.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/create_info_wrapper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/draw_call_tracker.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/graphics_pipeline_data.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/vk_deep_copy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/VkLayer_GF_amber_scoop/vulkan_commands.h
@@ -27,6 +28,7 @@ set(VkLayer_GF_amber_scoop_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/buffer_copy.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/command_buffer_data.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/draw_call_tracker.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/descriptor_set_data.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/graphics_pipeline_data.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/vk_deep_copy.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/vulkan_commands.cc

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/amber_scoop_layer.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/amber_scoop_layer.h
@@ -24,6 +24,7 @@
 
 #include "VkLayer_GF_amber_scoop/command_buffer_data.h"
 #include "VkLayer_GF_amber_scoop/create_info_wrapper.h"
+#include "VkLayer_GF_amber_scoop/descriptor_set_data.h"
 #include "VkLayer_GF_amber_scoop/graphics_pipeline_data.h"
 #include "gf_layers_layer_util/util.h"
 
@@ -57,21 +58,33 @@ struct DeviceData {
 
   // Other device functions:
 
+  // vkAllocate* and vkFree* functions:
   PFN_vkAllocateCommandBuffers vkAllocateCommandBuffers = {};
   PFN_vkFreeCommandBuffers vkFreeCommandBuffers = {};
+  PFN_vkAllocateDescriptorSets vkAllocateDescriptorSets = {};
+  PFN_vkFreeDescriptorSets vkFreeDescriptorSets = {};
+  // vkCreate* and vkDelete* functions:
   PFN_vkCreateBuffer vkCreateBuffer = {};
   PFN_vkDestroyBuffer vkDestroyBuffer = {};
   PFN_vkCreateGraphicsPipelines vkCreateGraphicsPipelines = {};
+  PFN_vkCreateDescriptorSetLayout vkCreateDescriptorSetLayout = {};
+  PFN_vkDestroyDescriptorSetLayout vkDestroyDescriptorSetLayout = {};
+  PFN_vkCreatePipelineLayout vkCreatePipelineLayout = {};
+  PFN_vkDestroyPipelineLayout vkDestroyPipelineLayout = {};
   PFN_vkCreateShaderModule vkCreateShaderModule = {};
   PFN_vkDestroyShaderModule vkDestroyShaderModule = {};
-  PFN_vkQueueSubmit vkQueueSubmit = {};
+  // vkCmd* functions:
   PFN_vkCmdBeginRenderPass vkCmdBeginRenderPass = {};
-  PFN_vkCmdDraw vkCmdDraw = {};
-  PFN_vkCmdDrawIndexed vkCmdDrawIndexed = {};
+  PFN_vkCmdBindDescriptorSets vkCmdBindDescriptorSets = {};
   PFN_vkCmdBindIndexBuffer vkCmdBindIndexBuffer = {};
   PFN_vkCmdBindPipeline vkCmdBindPipeline = {};
   PFN_vkCmdBindVertexBuffers vkCmdBindVertexBuffers = {};
+  PFN_vkCmdDraw vkCmdDraw = {};
+  PFN_vkCmdDrawIndexed vkCmdDrawIndexed = {};
   PFN_vkCmdPipelineBarrier vkCmdPipelineBarrier = {};
+  // Others:
+  PFN_vkQueueSubmit vkQueueSubmit = {};
+  PFN_vkUpdateDescriptorSets vkUpdateDescriptorSets = {};
 
   // Functions used by the layer but not intercepted:
   PFN_vkAllocateMemory vkAllocateMemory = {};
@@ -93,8 +106,12 @@ struct DeviceData {
 
   ProtectedMap<VkBuffer, BufferData> buffers;
   ProtectedMap<VkCommandBuffer, CommandBufferData> command_buffers_data;
+  ProtectedMap<VkDescriptorSet, DescriptorSetData> descriptor_sets;
+  ProtectedMap<VkDescriptorSetLayout, DescriptorSetLayoutData>
+      descriptor_set_layouts;
   ProtectedMap<VkPipeline, std::unique_ptr<GraphicsPipelineData>>
       graphics_pipelines;
+  ProtectedMap<VkPipelineLayout, PipelineLayoutData> pipeline_layouts;
 
   // Map of shader modules. Shared pointers are used because
   // |GraphicsPipelineData| may also hold a reference. |ShaderModuleData| will

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
@@ -46,14 +46,14 @@ class DescriptorSetData {
   // descriptors will be stored when updating the descriptor set.
   explicit DescriptorSetData(const DescriptorSetLayoutData* layout_data);
 
-  // Get the descriptor bindings of buffer type.
+  // Returns the descriptor bindings of buffer type.
   [[nodiscard]] const std::unordered_map<BindingNumber,
                                          std::vector<VkDescriptorBufferInfo>>*
   GetDescriptorBufferBindings() const {
     return &descriptor_buffer_bindings_;
   }
 
-  // Get pointer to the layout used to create this descriptor set.
+  // Returns pointer to the layout used to create this descriptor set.
   [[nodiscard]] const DescriptorSetLayoutData& GetDescriptorSetLayoutData()
       const {
     return *descriptor_set_layout_data_;
@@ -63,10 +63,6 @@ class DescriptorSetData {
   void WriteDescriptorSet(const VkWriteDescriptorSet& write_descriptor_set);
 
   // TODO(ilkkasaa): implement CopyDescriptorSet function.
-  /*
-  void CopyDescriptorSet(const VkCopyDescriptorSet& copy_descriptor_set) {
-    RUNTIME_ASSERT_MSG(false, "CopyDescriptorSet not implemented.");
-  }*/
 
  private:
   // Layout used to allocate this descriptor set.

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
@@ -53,9 +53,9 @@ class DescriptorSetData {
   }
 
   // Get pointer to the layout used to create this descriptor set.
-  [[nodiscard]] const DescriptorSetLayoutData* GetDescriptorSetLayoutData()
+  [[nodiscard]] const DescriptorSetLayoutData& GetDescriptorSetLayoutData()
       const {
-    return descriptor_set_layout_data_;
+    return *descriptor_set_layout_data_;
   }
 
   // Updates the descriptor sets' state with the given VkWriteDescriptorSet.
@@ -69,7 +69,7 @@ class DescriptorSetData {
 
  private:
   // Layout used to allocate this descriptor set.
-  const DescriptorSetLayoutData* descriptor_set_layout_data_;
+  std::unique_ptr<DescriptorSetLayoutData> descriptor_set_layout_data_;
   // |VkDescriptorBufferInfo| for each descriptor of "buffer" type.
   std::unordered_map<BindingNumber, std::vector<VkDescriptorBufferInfo>>
       descriptor_buffer_bindings_;

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
@@ -1,0 +1,86 @@
+// Copyright 2020 The gf-layers Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VKLAYER_GF_AMBER_SCOOP_DESCRIPTOR_SET_DATA_H
+#define VKLAYER_GF_AMBER_SCOOP_DESCRIPTOR_SET_DATA_H
+
+#include <vulkan/vulkan.h>
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "VkLayer_GF_amber_scoop/create_info_wrapper.h"
+
+namespace gf_layers::amber_scoop_layer {
+
+// This class is used to store descriptor set's state.
+class DescriptorSetData {
+ public:
+  // Type alias used to clarify the maps' key types.
+  using BindingNumber = uint32_t;
+
+  // Flattened descriptor types. Used f.ex. to easily choose where the
+  // descriptor writes are taken from and where they are stored.
+  enum FlattenedDescriptorType {
+    IMAGE_SAMPLER,
+    BUFFER,
+    TEXEL_BUFFER,
+    UNSUPPORTED
+  };
+
+  // Constructor. Stores the given pointer to the layout used to allocate this
+  // descriptor set and allocates the vectors where the information about
+  // descriptors will be stored when updating the descriptor set.
+  explicit DescriptorSetData(const DescriptorSetLayoutData* layout_data);
+
+  // Get the descriptor bindings of buffer type.
+  [[nodiscard]] const std::unordered_map<BindingNumber,
+                                         std::vector<VkDescriptorBufferInfo>>*
+  GetDescriptorBufferBindings() const {
+    return &descriptor_buffer_bindings_;
+  }
+
+  // Get pointer to the layout used to create this descriptor set.
+  [[nodiscard]] const DescriptorSetLayoutData* GetDescriptorSetLayoutData()
+      const {
+    return descriptor_set_layout_data_;
+  }
+
+  // Updates the descriptor sets' state with the given VkWriteDescriptorSet.
+  void WriteDescriptorSet(const VkWriteDescriptorSet& write_descriptor_set);
+
+  // TODO(ilkkasaa): implement CopyDescriptorSet function.
+  /*
+  void CopyDescriptorSet(const VkCopyDescriptorSet& copy_descriptor_set) {
+    RUNTIME_ASSERT_MSG(false, "CopyDescriptorSet not implemented.");
+  }*/
+
+ private:
+  // Layout used to allocate this descriptor set.
+  const DescriptorSetLayoutData* descriptor_set_layout_data_;
+  // |VkDescriptorBufferInfo| for each descriptor of "buffer" type.
+  std::unordered_map<BindingNumber, std::vector<VkDescriptorBufferInfo>>
+      descriptor_buffer_bindings_;
+  // Image and sampler bindings. Not used yet.
+  std::unordered_map<BindingNumber, std::vector<VkDescriptorImageInfo>>
+      image_and_sampler_bindings_;
+  // Texel buffer bindings. Not used yet.
+  std::unordered_map<BindingNumber, std::vector<VkBufferView>>
+      texel_buffer_view_bindings_;
+};
+
+}  // namespace gf_layers::amber_scoop_layer
+
+#endif  // VKLAYER_GF_AMBER_SCOOP_DESCRIPTOR_SET_DATA_H

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/descriptor_set_data.h
@@ -18,6 +18,7 @@
 #include <vulkan/vulkan.h>
 
 #include <cstdint>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/draw_call_tracker.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/draw_call_tracker.h
@@ -47,7 +47,7 @@ class DrawCallTracker {
     // Dynamic offsets used in this descriptor set. Key is the binding number of
     // the descriptor(s) and value is a list of dynamic offset(s) for the
     // binding.
-    std::unordered_map<BindingNumber, std::vector<BindingNumber>>
+    std::unordered_map<BindingNumber, std::vector<DynamicOffset>>
         dynamic_offsets;
   };
 

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vk_deep_copy.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vk_deep_copy.h
@@ -62,6 +62,30 @@ VkBufferCreateInfo DeepCopy(const VkBufferCreateInfo& create_info);
 // created with associated DeepCopy(...) function.
 void DeepDelete(const VkBufferCreateInfo& create_info);
 
+// Makes a deep copy of VkDescriptorSetLayoutBinding struct. The allocated
+// memory is not freed automatically. Use
+// DeepDelete(VkDescriptorSetLayoutBinding const*) to recursively free all
+// the allocated memory.
+VkDescriptorSetLayoutBinding DeepCopy(
+    const VkDescriptorSetLayoutBinding& descriptor_set_layout_binding);
+
+// Recursively deletes all the allocated memory of the given
+// VkDescriptorSetLayoutBinding struct. Should be used only for structs
+// created with associated DeepCopy(...) function.
+void DeepDelete(const VkDescriptorSetLayoutBinding& binding);
+
+// Makes a deep copy of VkDescriptorSetLayoutCreateInfo struct. The allocated
+// memory is not freed automatically. Use
+// DeepDelete(VkDescriptorSetLayoutCreateInfo const*) to recursively free all
+// the allocated memory.
+VkDescriptorSetLayoutCreateInfo DeepCopy(
+    const VkDescriptorSetLayoutCreateInfo& create_info);
+
+// Recursively deletes all the allocated memory of the given
+// VkDescriptorSetLayoutBinding struct. Should be used only for structs
+// created with associated DeepCopy(...) function.
+void DeepDelete(const VkDescriptorSetLayoutCreateInfo& create_info);
+
 // Makes a deep copy of VkGraphicsPipelineCreateInfo struct. The allocated
 // memory is not freed automatically. Use
 // DeepDelete(VkGraphicsPipelineCreateInfo const*) to recursively free all
@@ -73,6 +97,18 @@ VkGraphicsPipelineCreateInfo DeepCopy(
 // VkGraphicsPipelineCreateInfo struct. Should be used only for structs
 // created with associated DeepCopy(...) function.
 void DeepDelete(const VkGraphicsPipelineCreateInfo& create_info);
+
+// Makes a deep copy of VkPipelineLayoutCreateInfo struct. The allocated
+// memory is not freed automatically. Use
+// DeepDelete(VkPipelineLayoutCreateInfo const*) to recursively free all
+// the allocated memory.
+VkPipelineLayoutCreateInfo DeepCopy(
+    const VkPipelineLayoutCreateInfo& create_info);
+
+// Recursively deletes all the allocated memory of the given
+// VkPipelineLayoutCreateInfo struct. Should be used only for structs
+// created with associated DeepCopy(...) function.
+void DeepDelete(const VkPipelineLayoutCreateInfo& create_info);
 
 // Makes a deep copy of VkPipelineShaderStageCreateInfo struct. The allocated
 // memory is not freed automatically. Use

--- a/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_commands.h
+++ b/src/VkLayer_GF_amber_scoop/include/VkLayer_GF_amber_scoop/vulkan_commands.h
@@ -75,6 +75,44 @@ class CmdBeginRenderPass : public Cmd {
   VkSubpassContents contents_;
 };
 
+class CmdBindDescriptorSets : public Cmd {
+ public:
+  CmdBindDescriptorSets(VkPipelineBindPoint pipeline_bind_point,
+                        VkPipelineLayout layout, uint32_t first_set,
+                        uint32_t descriptor_set_count,
+                        const VkDescriptorSet* descriptor_sets,
+                        uint32_t dynamic_offset_count,
+                        const uint32_t* dynamic_offsets)
+      : pipeline_bind_point_(pipeline_bind_point),
+        layout_(layout),
+        first_set_(first_set) {
+    if (descriptor_set_count > 0) {
+      descriptor_sets_.assign(
+          descriptor_sets,
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          descriptor_sets + descriptor_set_count);
+    }
+
+    if (dynamic_offset_count > 0) {
+      dynamic_offsets_.assign(
+          dynamic_offsets,
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          dynamic_offsets + dynamic_offset_count);
+    }
+  }
+
+  // Sets vertex buffer bindings and their offsets.
+  void ProcessSubmittedCommand(
+      DrawCallTracker* draw_call_state_tracker) override;
+
+ private:
+  VkPipelineBindPoint pipeline_bind_point_;
+  VkPipelineLayout layout_;
+  uint32_t first_set_;
+  std::vector<VkDescriptorSet> descriptor_sets_;
+  std::vector<uint32_t> dynamic_offsets_;
+};
+
 class CmdBindIndexBuffer : public Cmd {
  public:
   CmdBindIndexBuffer(VkBuffer buffer, VkDeviceSize offset,

--- a/src/VkLayer_GF_amber_scoop/src/amber_scoop_layer.cc
+++ b/src/VkLayer_GF_amber_scoop/src/amber_scoop_layer.cc
@@ -494,7 +494,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(
 }
 
 //
-// Our vkCreateShaderModule function.
+// Our vkCreatePipelineLayout function.
 //
 VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineLayout(
     VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,

--- a/src/VkLayer_GF_amber_scoop/src/amber_scoop_layer.cc
+++ b/src/VkLayer_GF_amber_scoop/src/amber_scoop_layer.cc
@@ -118,6 +118,27 @@ VKAPI_ATTR void VKAPI_CALL vkCmdBeginRenderPass(
 }
 
 //
+// Our vkCmdBindDescriptorSets function.
+//
+VKAPI_ATTR void VKAPI_CALL vkCmdBindDescriptorSets(
+    VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
+    VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
+    const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
+    const uint32_t* pDynamicOffsets) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(commandBuffer));
+
+  // Call the original function.
+  device_data->vkCmdBindDescriptorSets(
+      commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount,
+      pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
+
+  AddCommand(device_data, commandBuffer,
+             std::make_unique<CmdBindDescriptorSets>(
+                 pipelineBindPoint, layout, firstSet, descriptorSetCount,
+                 pDescriptorSets, dynamicOffsetCount, pDynamicOffsets));
+}
+
+//
 // Our vkCmdBindIndexBuffer function.
 //
 VKAPI_ATTR void VKAPI_CALL vkCmdBindIndexBuffer(VkCommandBuffer commandBuffer,
@@ -294,6 +315,52 @@ void vkFreeCommandBuffers(VkDevice device, VkCommandPool commandPool,
 }
 
 //
+// Our vkAllocateDescriptorSets function.
+//
+VKAPI_ATTR VkResult VKAPI_CALL vkAllocateDescriptorSets(
+    VkDevice device, VkDescriptorSetAllocateInfo const* pAllocateInfo,
+    VkDescriptorSet* pDescriptorSets) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  VkResult result = device_data->vkAllocateDescriptorSets(device, pAllocateInfo,
+                                                          pDescriptorSets);
+  if (result != VK_SUCCESS) {
+    return result;
+  }
+
+  // Store all descriptor sets and the layouts used to allocate them.
+  for (uint32_t i = 0; i < pAllocateInfo->descriptorSetCount; i++) {
+    const DescriptorSetLayoutData* layout_data =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        device_data->descriptor_set_layouts.Get(pAllocateInfo->pSetLayouts[i]);
+    device_data->descriptor_sets.Put(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        pDescriptorSets[i], DescriptorSetData(layout_data));
+  }
+  return result;
+}
+
+//
+// Our vkFreeDescriptorSets function.
+//
+void vkFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool,
+                          uint32_t descriptorSetCount,
+                          VkDescriptorSet const* pDescriptorSets) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  device_data->vkFreeDescriptorSets(device, descriptorPool, descriptorSetCount,
+                                    pDescriptorSets);
+
+  // Remove descriptor sets from the device data.
+  for (uint32_t i = 0; i < descriptorSetCount; i++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    device_data->descriptor_sets.Remove(pDescriptorSets[i]);
+  }
+}
+
+//
 // Our vkCreateBuffer function.
 //
 VKAPI_ATTR VkResult VKAPI_CALL
@@ -335,6 +402,43 @@ void vkDestroyBuffer(VkDevice device, VkBuffer buffer,
   device_data->vkDestroyBuffer(device, buffer, pAllocator);
 
   device_data->buffers.Remove(buffer);
+}
+
+//
+// Our vkCreateDescriptorSetLayout function.
+//
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateDescriptorSetLayout(
+    VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator,
+    VkDescriptorSetLayout* pSetLayout) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  VkResult result = device_data->vkCreateDescriptorSetLayout(
+      device, pCreateInfo, pAllocator, pSetLayout);
+
+  if (result != VK_SUCCESS) {
+    return result;
+  }
+
+  device_data->descriptor_set_layouts.Put(
+      *pSetLayout, DescriptorSetLayoutData(*pCreateInfo));
+  return result;
+}
+
+//
+// Our vkDestroyDescriptorSetLayout function.
+//
+void vkDestroyDescriptorSetLayout(VkDevice device,
+                                  VkDescriptorSetLayout descriptorSetLayout,
+                                  VkAllocationCallbacks* pAllocator) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  device_data->vkDestroyDescriptorSetLayout(device, descriptorSetLayout,
+                                            pAllocator);
+  // Remove the layout from the device data.
+  device_data->descriptor_set_layouts.Remove(descriptorSetLayout);
 }
 
 //
@@ -387,6 +491,38 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(
   }
 
   return result;
+}
+
+//
+// Our vkCreateShaderModule function.
+//
+VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineLayout(
+    VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator,
+    VkPipelineLayout* pPipelineLayout) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  VkResult result = device_data->vkCreatePipelineLayout(
+      device, pCreateInfo, pAllocator, pPipelineLayout);
+  if (result != VK_SUCCESS) {
+    return result;
+  }
+  device_data->pipeline_layouts.Put(*pPipelineLayout,
+                                    PipelineLayoutData(*pCreateInfo));
+  return result;
+}
+
+//
+// Our vkDestroyPipelineLayout function.
+//
+void vkDestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout,
+                             VkAllocationCallbacks const* pAllocator) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+  // Call the original function.
+  device_data->vkDestroyPipelineLayout(device, pipelineLayout, pAllocator);
+
+  device_data->pipeline_layouts.Remove(pipelineLayout);
 }
 
 //
@@ -462,9 +598,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit(VkQueue queue,
       // command buffer being processed, i.e. what pipeline is bound, push
       // constant values, bound vertex and index buffers, etc. This information
       // is needed when a draw call needs to be processed to an Amber file.
-      DrawCallTracker draw_call_tracker(global_data);
-      draw_call_tracker.GetDrawCallState()->command_buffer = command_buffer;
-      draw_call_tracker.GetDrawCallState()->queue = queue;
+      DrawCallTracker draw_call_tracker(global_data, command_buffer, queue);
 
       // Process all submitted commands. Most of the commands update the state
       // of the draw call tracker and draw commands generate the Amber files.
@@ -484,6 +618,38 @@ VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit(VkQueue queue,
       device_data->vkQueueSubmit(queue, submitCount, pSubmits, fence);
 
   return result;
+}
+
+//
+// Our vkUpdateDescriptorSets function.
+//
+void vkUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
+                            VkWriteDescriptorSet const* pDescriptorWrites,
+                            uint32_t descriptorCopyCount,
+                            VkCopyDescriptorSet const* pDescriptorCopies) {
+  DeviceData* device_data = GetDeviceData(DeviceKey(device));
+
+  // Call the original function.
+  device_data->vkUpdateDescriptorSets(device, descriptorWriteCount,
+                                      pDescriptorWrites, descriptorCopyCount,
+                                      pDescriptorCopies);
+
+  if (descriptorCopyCount > 0) {
+    RUNTIME_ASSERT_MSG(false, "Not handling descriptor copies yet.");
+  }
+
+  // Go through all descriptor writes.
+  for (uint32_t descriptor_write_idx = 0;
+       descriptor_write_idx < descriptorWriteCount; descriptor_write_idx++) {
+    const VkWriteDescriptorSet& write_descriptor_set =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        pDescriptorWrites[descriptor_write_idx];
+
+    // Update the descriptor set.
+    DescriptorSetData* descriptor_set =
+        device_data->descriptor_sets.Get(write_descriptor_set.dstSet);
+    descriptor_set->WriteDescriptorSet(write_descriptor_set);
+  }
 }
 
 // The following functions are standard Vulkan functions that most Vulkan layers
@@ -702,13 +868,21 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(
 
   HANDLE(vkAllocateCommandBuffers)
   HANDLE(vkFreeCommandBuffers)
+  HANDLE(vkAllocateDescriptorSets)
+  HANDLE(vkFreeDescriptorSets)
   HANDLE(vkCreateBuffer)
   HANDLE(vkDestroyBuffer)
+  HANDLE(vkCreateDescriptorSetLayout)
+  HANDLE(vkDestroyDescriptorSetLayout)
   HANDLE(vkCreateGraphicsPipelines)
+  HANDLE(vkCreatePipelineLayout)
+  HANDLE(vkDestroyPipelineLayout)
   HANDLE(vkCreateShaderModule)
   HANDLE(vkDestroyShaderModule)
   HANDLE(vkQueueSubmit)
+  HANDLE(vkUpdateDescriptorSets)
   HANDLE(vkCmdBeginRenderPass)
+  HANDLE(vkCmdBindDescriptorSets)
   HANDLE(vkCmdBindIndexBuffer)
   HANDLE(vkCmdBindPipeline)
   HANDLE(vkCmdBindVertexBuffers)
@@ -762,13 +936,21 @@ vkGetDeviceProcAddr(VkDevice device, const char* pName) {
   // Other device functions that this layer intercepts:
   HANDLE(vkAllocateCommandBuffers)
   HANDLE(vkFreeCommandBuffers)
+  HANDLE(vkAllocateDescriptorSets)
+  HANDLE(vkFreeDescriptorSets)
   HANDLE(vkCreateBuffer)
   HANDLE(vkDestroyBuffer)
+  HANDLE(vkCreateDescriptorSetLayout)
+  HANDLE(vkDestroyDescriptorSetLayout)
   HANDLE(vkCreateGraphicsPipelines)
+  HANDLE(vkCreatePipelineLayout)
+  HANDLE(vkDestroyPipelineLayout)
   HANDLE(vkCreateShaderModule)
   HANDLE(vkDestroyShaderModule)
   HANDLE(vkQueueSubmit)
+  HANDLE(vkUpdateDescriptorSets)
   HANDLE(vkCmdBeginRenderPass)
+  HANDLE(vkCmdBindDescriptorSets)
   HANDLE(vkCmdBindIndexBuffer)
   HANDLE(vkCmdBindPipeline)
   HANDLE(vkCmdBindVertexBuffers)

--- a/src/VkLayer_GF_amber_scoop/src/descriptor_set_data.cc
+++ b/src/VkLayer_GF_amber_scoop/src/descriptor_set_data.cc
@@ -43,7 +43,7 @@ DescriptorSetData::FlattenedDescriptorType GetFlattenedDescriptorType(
     }
     case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
     case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
-      // If descriptorType is any of above types, each element of
+      // If descriptorType is any of the types above, each element of
       // pTexelBufferView must be either a valid VkBufferView handle (or
       // VK_NULL_HANDLE if the nullDescriptor feature is enabled).
       return DescriptorSetData::TEXEL_BUFFER;

--- a/src/VkLayer_GF_amber_scoop/src/descriptor_set_data.cc
+++ b/src/VkLayer_GF_amber_scoop/src/descriptor_set_data.cc
@@ -69,7 +69,8 @@ DescriptorSetData::FlattenedDescriptorType GetFlattenedDescriptorType(
 }  // namespace
 
 DescriptorSetData::DescriptorSetData(const DescriptorSetLayoutData* layout_data)
-    : descriptor_set_layout_data_(layout_data) {
+    : descriptor_set_layout_data_(std::make_unique<DescriptorSetLayoutData>(
+          layout_data->GetCreateInfo())) {
   const VkDescriptorSetLayoutCreateInfo& create_info =
       layout_data->GetCreateInfo();
 

--- a/src/VkLayer_GF_amber_scoop/src/descriptor_set_data.cc
+++ b/src/VkLayer_GF_amber_scoop/src/descriptor_set_data.cc
@@ -1,0 +1,167 @@
+// Copyright 2020 The gf-layers Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "VkLayer_GF_amber_scoop/descriptor_set_data.h"
+
+// <algorithm> is used by GCC's libstdc++, but not LLVM's libc++.
+#include <algorithm>  // IWYU pragma: keep
+// <cstdio> and <cstdlib> required by LOG and ASSERT macros, but IWYU doesn't
+// notice it, so we need to manually keep the includes.
+#include <cstdio>   // IWYU pragma: keep
+#include <cstdlib>  // IWYU pragma: keep
+
+#include "gf_layers_layer_util/logging.h"
+
+namespace gf_layers::amber_scoop_layer {
+namespace {
+
+// Returns a flattened descriptor types. See documentation of the
+// |FlattenedDescriptorType| enum for more info.
+DescriptorSetData::FlattenedDescriptorType GetFlattenedDescriptorType(
+    VkDescriptorType descriptor_type) {
+  switch (descriptor_type) {
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
+      // If descriptorType is any of the types above, pImageInfo must be a
+      // valid pointer to an array of descriptorCount valid
+      // VkDescriptorImageInfo structures
+      return DescriptorSetData::IMAGE_SAMPLER;
+    }
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
+      // If descriptorType is any of above types, each element of
+      // pTexelBufferView must be either a valid VkBufferView handle (or
+      // VK_NULL_HANDLE if the nullDescriptor feature is enabled).
+      return DescriptorSetData::TEXEL_BUFFER;
+    }
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
+      // If descriptorType is any of the types above, pBufferInfo must be a
+      // valid pointer to an array of descriptorCount valid
+      // VkDescriptorBufferInfo structures.
+      return DescriptorSetData::BUFFER;
+    }
+    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+    case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+      return DescriptorSetData::UNSUPPORTED;
+    case VK_DESCRIPTOR_TYPE_MAX_ENUM: {
+      RUNTIME_ASSERT_MSG(false, "Should be unreachable.");
+    }
+  }
+}
+}  // namespace
+
+DescriptorSetData::DescriptorSetData(const DescriptorSetLayoutData* layout_data)
+    : descriptor_set_layout_data_(layout_data) {
+  const VkDescriptorSetLayoutCreateInfo& create_info =
+      layout_data->GetCreateInfo();
+
+  // Initialize buffer/image/sampler binding vectors with correct sizes.
+  for (uint32_t binding_number = 0; binding_number < create_info.bindingCount;
+       binding_number++) {
+    const VkDescriptorSetLayoutBinding& binding =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        create_info.pBindings[binding_number];
+    switch (GetFlattenedDescriptorType(binding.descriptorType)) {
+      case IMAGE_SAMPLER:
+        DEBUG_ASSERT_MSG(false, "Images and samplers are not implemented.");
+        break;
+      case BUFFER: {
+        descriptor_buffer_bindings_[binding_number] =
+            std::vector<VkDescriptorBufferInfo>(binding.descriptorCount);
+        break;
+      }
+      case TEXEL_BUFFER:
+        DEBUG_ASSERT_MSG(false, "Texel buffers not implemented.");
+        break;
+      case UNSUPPORTED:
+        DEBUG_ASSERT_MSG(false, "Unsupported buffer type.");
+        break;
+    }
+  }
+}
+
+void DescriptorSetData::WriteDescriptorSet(
+    const VkWriteDescriptorSet& write_descriptor_set) {
+  // From the Vulkan spec:
+  // If VkDescriptorSetLayoutBinding for dstSet at dstBinding is not equal
+  // to VK_DESCRIPTOR_TYPE_MUTABLE_VALVE, descriptorType must be the same
+  // type as that specified in VkDescriptorSetLayoutBinding for dstSet at
+  // dstBinding.
+
+  const VkDescriptorSetLayoutBinding& binding =
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      descriptor_set_layout_data_->GetCreateInfo()
+          .pBindings[write_descriptor_set.dstBinding];
+  DEBUG_ASSERT_MSG(
+      binding.descriptorType == write_descriptor_set.descriptorType,
+      "Write descriptorType and descriptor's type defined in "
+      "VkDescriptorSetLayout doesn't match.");
+
+  switch (GetFlattenedDescriptorType(write_descriptor_set.descriptorType)) {
+    case IMAGE_SAMPLER:
+      // TODO(ilkkasaa): implement images and samplers here.
+      RUNTIME_ASSERT_MSG(false, "Images and samplers are not implemented.");
+    case BUFFER: {
+      // From the Vulkan spec:
+      // If the dstBinding has fewer than descriptorCount array
+      // elements remaining starting from dstArrayElement, then the remainder
+      // will be used to update the subsequent binding - dstBinding+1 starting
+      // at array element zero. If a binding has a descriptorCount of zero, it
+      // is skipped. This behavior applies recursively, with the update
+      // affecting consecutive bindings as needed to update all descriptorCount
+      // descriptors.
+      uint32_t binding_idx = write_descriptor_set.dstBinding;
+      uint32_t array_element = write_descriptor_set.dstArrayElement;
+      for (uint32_t descriptor_read_idx = 0;
+           descriptor_read_idx < write_descriptor_set.descriptorCount;
+           descriptor_read_idx++) {
+        // Jump to the next binding if the current binding has no more array
+        // elements left. This will also skip bindings with descriptorCount of
+        // zero. See the quote from the Vulkan spec above.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        while (array_element >= descriptor_set_layout_data_->GetCreateInfo()
+                                    .pBindings[binding_idx]
+                                    .descriptorCount) {
+          binding_idx++;
+          // Start from next binding's first array element.
+          array_element = 0;
+          DEBUG_ASSERT_MSG(
+              binding_idx <
+                  descriptor_set_layout_data_->GetCreateInfo().bindingCount,
+              "Descriptor set binding overflow.");
+        }
+        descriptor_buffer_bindings_[binding_idx][array_element] =
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            write_descriptor_set.pBufferInfo[descriptor_read_idx];
+        // Jump to the next array element.
+        array_element++;
+      }
+      break;
+    }
+    case TEXEL_BUFFER:
+      // TODO(ilkkasaa): implement uniform / storage texel buffers.
+      RUNTIME_ASSERT_MSG(
+          false, "Uniform / storage texel buffers are not implemented.");
+    case UNSUPPORTED:
+      break;
+  }
+}
+
+}  // namespace gf_layers::amber_scoop_layer

--- a/src/VkLayer_GF_amber_scoop/src/descriptor_set_data.cc
+++ b/src/VkLayer_GF_amber_scoop/src/descriptor_set_data.cc
@@ -64,6 +64,7 @@ DescriptorSetData::FlattenedDescriptorType GetFlattenedDescriptorType(
       RUNTIME_ASSERT_MSG(false, "Should be unreachable.");
     }
   }
+  return DescriptorSetData::UNSUPPORTED;
 }
 }  // namespace
 

--- a/src/VkLayer_GF_amber_scoop/src/draw_call_tracker.cc
+++ b/src/VkLayer_GF_amber_scoop/src/draw_call_tracker.cc
@@ -174,7 +174,7 @@ void DrawCallTracker::BindGraphicsDescriptorSet(
   const DescriptorSetData* descriptor_set_data =
       GetDeviceData()->descriptor_sets.Get(descriptor_set);
   const VkDescriptorSetLayoutCreateInfo& layout_create_info =
-      descriptor_set_data->GetDescriptorSetLayoutData()->GetCreateInfo();
+      descriptor_set_data->GetDescriptorSetLayoutData().GetCreateInfo();
 
   // Loop through all bindings in the descriptor set data to check if there's
   // any UNIFORM_BUFFER_DYNAMIC or STORAGE_BUFFER_DYNAMIC descriptors in the
@@ -374,7 +374,7 @@ void DrawCallTracker::CreateDescriptorSetDeclarations(
       uint32_t descriptor_count =
           // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
           descriptor_set_data->GetDescriptorSetLayoutData()
-              ->GetCreateInfo()
+              .GetCreateInfo()
               .pBindings[binding_number]
               .descriptorCount;
       // List of buffer names. One buffer name per array element.
@@ -382,7 +382,7 @@ void DrawCallTracker::CreateDescriptorSetDeclarations(
 
       const auto& descriptor_set_layout =
           descriptor_set_data->GetDescriptorSetLayoutData()
-              ->GetCreateInfo()
+              .GetCreateInfo()
               .pBindings;
 
       // Initialize dynamic offsets with zeroes. Initial values are used if the

--- a/src/VkLayer_GF_amber_scoop/src/draw_call_tracker.cc
+++ b/src/VkLayer_GF_amber_scoop/src/draw_call_tracker.cc
@@ -460,8 +460,8 @@ void DrawCallTracker::CreateDescriptorSetDeclarations(
                    << binding_number;
 
       // Add descriptor buffer range and offsets.
-      pipeline_str << " DESCRIPTOR_RANGE" << descriptor_range_string.str();
       pipeline_str << " DESCRIPTOR_OFFSET" << descriptor_offset_string.str();
+      pipeline_str << " DESCRIPTOR_RANGE" << descriptor_range_string.str();
 
       // Add dynamic offset(s).
       if (descriptor_set_layout->descriptorType ==

--- a/src/VkLayer_GF_amber_scoop/src/draw_call_tracker.cc
+++ b/src/VkLayer_GF_amber_scoop/src/draw_call_tracker.cc
@@ -488,9 +488,9 @@ void DrawCallTracker::CreateDescriptorSetDeclarations(
                    << binding_number;
 
       // Add descriptor buffer range and offsets.
+      pipeline_str << dynamic_offset_string.str();
       pipeline_str << " DESCRIPTOR_OFFSET" << descriptor_offset_string.str();
       pipeline_str << " DESCRIPTOR_RANGE" << descriptor_range_string.str();
-      pipeline_str << dynamic_offset_string.str();
       pipeline_str << std::endl;
     }
 

--- a/src/VkLayer_GF_amber_scoop/src/vk_deep_copy.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vk_deep_copy.cc
@@ -58,10 +58,10 @@ VkDescriptorSetLayoutCreateInfo DeepCopy(
     const VkDescriptorSetLayoutCreateInfo& create_info) {
   VkDescriptorSetLayoutCreateInfo result = create_info;
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  VkDescriptorSetLayoutBinding* bindings;
-  bindings = create_info.bindingCount > 0
-                 ? new VkDescriptorSetLayoutBinding[create_info.bindingCount]
-                 : nullptr;
+  VkDescriptorSetLayoutBinding* bindings =
+      create_info.bindingCount > 0
+          ? new VkDescriptorSetLayoutBinding[create_info.bindingCount]
+          : nullptr;
 
   for (uint32_t i = 0; i < create_info.bindingCount; i++) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)

--- a/src/VkLayer_GF_amber_scoop/src/vk_deep_copy.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vk_deep_copy.cc
@@ -58,7 +58,10 @@ VkDescriptorSetLayoutCreateInfo DeepCopy(
     const VkDescriptorSetLayoutCreateInfo& create_info) {
   VkDescriptorSetLayoutCreateInfo result = create_info;
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  auto* bindings = new VkDescriptorSetLayoutBinding[create_info.bindingCount];
+  VkDescriptorSetLayoutBinding* bindings;
+  bindings = create_info.bindingCount > 0
+                 ? new VkDescriptorSetLayoutBinding[create_info.bindingCount]
+                 : nullptr;
 
   for (uint32_t i = 0; i < create_info.bindingCount; i++) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)

--- a/src/VkLayer_GF_amber_scoop/src/vk_deep_copy.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vk_deep_copy.cc
@@ -32,6 +32,51 @@ void DeepDelete(const VkBufferCreateInfo& create_info) {
   }
 }
 
+VkDescriptorSetLayoutBinding DeepCopy(
+    const VkDescriptorSetLayoutBinding& descriptor_set_layout_binding) {
+  VkDescriptorSetLayoutBinding result = descriptor_set_layout_binding;
+
+  if (descriptor_set_layout_binding.pImmutableSamplers == nullptr) {
+    return result;
+  }
+
+  // Copy immutable sampler handles.
+  result.pImmutableSamplers =
+      CopyArray(descriptor_set_layout_binding.pImmutableSamplers,
+                descriptor_set_layout_binding.descriptorCount);
+
+  return result;
+}
+
+void DeepDelete(const VkDescriptorSetLayoutBinding& binding) {
+  // Delete immutable sampler handles.
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  delete[] binding.pImmutableSamplers;
+}
+
+VkDescriptorSetLayoutCreateInfo DeepCopy(
+    const VkDescriptorSetLayoutCreateInfo& create_info) {
+  VkDescriptorSetLayoutCreateInfo result = create_info;
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  auto* bindings = new VkDescriptorSetLayoutBinding[create_info.bindingCount];
+
+  for (uint32_t i = 0; i < create_info.bindingCount; i++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    bindings[i] = DeepCopy(create_info.pBindings[i]);
+  }
+  result.pBindings = bindings;
+  return result;
+}
+
+void DeepDelete(const VkDescriptorSetLayoutCreateInfo& create_info) {
+  for (uint32_t i = 0; i < create_info.bindingCount; i++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    DeepDelete(create_info.pBindings[i]);
+  }
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  delete[] create_info.pBindings;
+}
+
 VkGraphicsPipelineCreateInfo DeepCopy(
     const VkGraphicsPipelineCreateInfo& create_info) {
   VkGraphicsPipelineCreateInfo result = create_info;
@@ -122,6 +167,23 @@ void DeepDelete(const VkGraphicsPipelineCreateInfo& create_info) {
   delete create_info.pRasterizationState;
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   delete create_info.pDepthStencilState;
+}
+
+VkPipelineLayoutCreateInfo DeepCopy(
+    const VkPipelineLayoutCreateInfo& create_info) {
+  VkPipelineLayoutCreateInfo result = create_info;
+  result.pSetLayouts =
+      CopyArray(create_info.pSetLayouts, create_info.setLayoutCount);
+  result.pPushConstantRanges = CopyArray(create_info.pPushConstantRanges,
+                                         create_info.pushConstantRangeCount);
+  return result;
+}
+
+void DeepDelete(const VkPipelineLayoutCreateInfo& create_info) {
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  delete[] create_info.pSetLayouts;
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  delete[] create_info.pPushConstantRanges;
 }
 
 VkPipelineShaderStageCreateInfo DeepCopy(

--- a/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
+++ b/src/VkLayer_GF_amber_scoop/src/vulkan_commands.cc
@@ -18,7 +18,13 @@
 #include <algorithm>  // IWYU pragma: keep
 #include <unordered_map>
 
+// <cstdio> and <cstdlib> required by LOG and ASSERT macros, but IWYU doesn't
+// notice it, so we need to manually keep the includes.
+#include <cstdio>   // IWYU pragma: keep
+#include <cstdlib>  // IWYU pragma: keep
+
 #include "VkLayer_GF_amber_scoop/draw_call_tracker.h"
+#include "gf_layers_layer_util/logging.h"
 
 namespace gf_layers::amber_scoop_layer {
 
@@ -32,6 +38,31 @@ void CmdBeginRenderPass::ProcessSubmittedCommand(
       &render_pass_begin_;
   // TODO(ilkkasaa): currently only one subpass is supported.
   draw_call_state_tracker->GetDrawCallState()->current_subpass = 0;
+}
+
+void CmdBindDescriptorSets::ProcessSubmittedCommand(
+    DrawCallTracker* draw_call_state_tracker) {
+  if (pipeline_bind_point_ != VK_PIPELINE_BIND_POINT_GRAPHICS) {
+    DEBUG_LOG("Only graphics pipeline bind point is currently supported.");
+    return;
+  }
+
+  // Index for reading data from the dynamic offset array. Value is updated in
+  // the BindGraphicsDescriptorSet function.
+  uint32_t dynamic_offset_idx = 0;
+  // Loop through all descriptor sets to be updated. Update the draw call
+  // tracker's state with the descriptor sets and their dynamic offsets.
+  uint32_t descriptor_set_idx = 0;
+  for (const VkDescriptorSet& descriptor_set : descriptor_sets_) {
+    draw_call_state_tracker->BindGraphicsDescriptorSet(
+        first_set_ + descriptor_set_idx, descriptor_set, dynamic_offsets_,
+        &dynamic_offset_idx);
+    descriptor_set_idx++;
+  }
+
+  DEBUG_ASSERT_MSG(dynamic_offset_idx == dynamic_offsets_.size(),
+                   "dynamicOffsetCount is not equal to the number of dynamic "
+                   "descriptors in the sets being bound.");
 }
 
 void CmdBindIndexBuffer::ProcessSubmittedCommand(
@@ -48,7 +79,7 @@ void CmdBindPipeline::ProcessSubmittedCommand(
     DrawCallTracker* draw_call_state_tracker) {
   // Currently we are interested in graphics pipelines only.
   if (pipeline_bind_point_ == VK_PIPELINE_BIND_POINT_GRAPHICS) {
-    draw_call_state_tracker->GetDrawCallState()->graphics_pipeline = pipeline_;
+    draw_call_state_tracker->BindGraphicsPipeline(pipeline_);
   }
 }
 

--- a/src/iwyu.imp
+++ b/src/iwyu.imp
@@ -28,4 +28,8 @@
   # Android <mutex>.
   { include: ["<__mutex_base>", "private", "<mutex>", "public"] },
 
+  # Workaround for an old IWYU bug: <ext/alloc_traits.h> is wanted to be included if a vector
+  # is accessed with operator[].
+  # https://github.com/include-what-you-use/include-what-you-use/issues/166
+  { include: [ "<ext/alloc_traits.h>", private, "<vector>", public ] },
 ]


### PR DESCRIPTION
Adds functionality to track descriptor set bindings and uniform buffers.
Stores the captured uniform buffers to binary files.
Also contains preparation to support other descriptor types.